### PR TITLE
Track n_atoms

### DIFF
--- a/smee/ff/_ff.py
+++ b/smee/ff/_ff.py
@@ -98,6 +98,9 @@ class TensorTopology:
     """A tensor representation of a molecular topology that has been assigned force
     field parameters."""
 
+    n_atoms: int
+    """The number of atoms in the topology."""
+
     parameters: dict[str, ParameterMap]
     """The parameters that have been assigned to the topology."""
     v_sites: VSiteMap | None = None
@@ -494,11 +497,12 @@ def convert_interchange(
 
     tensor_topologies = [
         TensorTopology(
-            {
+            n_atoms=topologies[i].n_atoms,
+            parameters={
                 potential.type: parameter_maps_by_handler[potential.type][i]
                 for potential in potentials
             },
-            v_site_maps[i],
+            v_sites=v_site_maps[i],
         )
         for i in range(len(topologies))
     ]

--- a/smee/potentials/nonbonded.py
+++ b/smee/potentials/nonbonded.py
@@ -40,7 +40,7 @@ def lorentz_berthelot(
         The epsilon [kcal / mol] and sigma [Å] values of each pair, each with
         ``shape=(n_pairs, 1)``.
     """
-    return (epsilon_a * epsilon_b).sqrt(), 0.5 * (sigma_a + sigma_b)
+    return (epsilon_a * epsilon_b + 1.0e-8).sqrt(), 0.5 * (sigma_a + sigma_b)
 
 
 def compute_pairwise(

--- a/smee/potentials/nonbonded.py
+++ b/smee/potentials/nonbonded.py
@@ -40,7 +40,11 @@ def lorentz_berthelot(
         The epsilon [kcal / mol] and sigma [Å] values of each pair, each with
         ``shape=(n_pairs, 1)``.
     """
-    return (epsilon_a * epsilon_b + 1.0e-8).sqrt(), 0.5 * (sigma_a + sigma_b)
+
+    epsilon_sqr = epsilon_a * epsilon_b
+    epsilon = torch.where(epsilon_sqr > 0.0, epsilon_sqr.sqrt(), 0.0)
+
+    return epsilon, 0.5 * (sigma_a + sigma_b)
 
 
 def compute_pairwise(


### PR DESCRIPTION
## Description

This PR tracks the number of atoms in a topology. It further sneaks in the addition of an eps term to LB mixing rules to prevent NaN when back-propagating until a proper fix is in place.

## Status
- [X] Ready to go