### PR TITLE
Use double precision as default

### DIFF
--- a/smee/ff/_ff.py
+++ b/smee/ff/_ff.py
@@ -235,7 +235,8 @@ def _handlers_to_potential(
                 for column in parameter_cols
             ]
             for parameter_key in parameter_keys
-        ]
+        ],
+        dtype=torch.float64,
     )
 
     attributes = None
@@ -251,7 +252,8 @@ def _handlers_to_potential(
             for k, v in attributes_by_column.items()
         }
         attributes = torch.tensor(
-            [attributes_by_column[column] for column in attribute_cols]
+            [attributes_by_column[column] for column in attribute_cols],
+            dtype=torch.float64,
         )
 
     potential = TensorPotential(

--- a/smee/ff/nonbonded.py
+++ b/smee/ff/nonbonded.py
@@ -104,7 +104,9 @@ def convert_nonbonded_handlers(
                     assignment_map[atom_idx][parameter_key_to_idx[mult_key]] += -1.0
                     assignment_map[v_site_idx][parameter_key_to_idx[mult_key]] += 1.0
 
-        assignment_matrix = torch.zeros((n_particles, len(potential.parameters)))
+        assignment_matrix = torch.zeros(
+            (n_particles, len(potential.parameters)), dtype=torch.float64
+        )
 
         for particle_idx in assignment_map:
             for parameter_idx, count in assignment_map[particle_idx].items():
@@ -117,7 +119,7 @@ def convert_nonbonded_handlers(
         )
 
         parameter_map = smee.ff.NonbondedParameterMap(
-            assignment_matrix=assignment_matrix.float().to_sparse(),
+            assignment_matrix=assignment_matrix.to_sparse(),
             exclusions=exclusions,
             exclusion_scale_idxs=exclusion_scale_idxs,
         )

--- a/smee/ff/valence.py
+++ b/smee/ff/valence.py
@@ -49,13 +49,15 @@ def convert_valence_handlers(
     for handler in handlers:
         particle_idxs = [topology_key.atom_indices for topology_key in handler.key_map]
 
-        assignment_matrix = torch.zeros((len(particle_idxs), len(potential.parameters)))
+        assignment_matrix = torch.zeros(
+            (len(particle_idxs), len(potential.parameters)), dtype=torch.float64
+        )
 
         for i, parameter_key in enumerate(handler.key_map.values()):
             assignment_matrix[i, parameter_key_to_idx[parameter_key]] += 1.0
 
         parameter_map = smee.ff.ValenceParameterMap(
-            torch.tensor(particle_idxs), assignment_matrix.float().to_sparse()
+            torch.tensor(particle_idxs), assignment_matrix.to_sparse()
         )
         parameter_maps.append(parameter_map)
 

--- a/smee/potentials/_potentials.py
+++ b/smee/potentials/_potentials.py
@@ -45,12 +45,12 @@ def compute_energy_potential(
         The potential energy of the conformer(s) [kcal / mol].
     """
 
+    conformer = conformer.float()
+
     if len(conformer.shape) == 2:
         conformer = torch.unsqueeze(conformer, 0)
 
-    parameter_values = (
-        parameters.assignment_matrix.float() @ potential.parameters.float()
-    )
+    parameter_values = parameters.assignment_matrix @ potential.parameters
 
     importlib.import_module("smee.potentials.nonbonded")
     importlib.import_module("smee.potentials.valence")
@@ -100,6 +100,8 @@ def compute_energy(
     Returns:
         The potential energy of the conformer(s) [kcal / mol].
     """
+
+    conformer = conformer.float()
 
     if conformer.ndim == 2:
         conformer = torch.unsqueeze(conformer, 0)

--- a/smee/potentials/nonbonded.py
+++ b/smee/potentials/nonbonded.py
@@ -4,6 +4,7 @@ import openff.units
 import torch
 
 import smee.potentials
+import smee.utils
 
 _UNIT = openff.units.unit
 
@@ -67,13 +68,13 @@ def compute_pairwise(
     n_particles = conformer.shape[-2]
 
     pair_idxs = torch.triu_indices(n_particles, n_particles, 1).T
-    pair_scales = torch.ones(len(pair_idxs))
+    pair_scales = smee.utils.ones_like(len(pair_idxs), other=exclusion_scales)
 
     if len(exclusions) > 0:
         exclusions, _ = exclusions.sort(dim=1)
 
         i, j = exclusions[:, 0], exclusions[:, 1]
-        exclusions_1d = ((i * (2 * n_particles - i - 1)) / 2 + j - i - 1).int()
+        exclusions_1d = ((i * (2 * n_particles - i - 1)) / 2 + j - i - 1).long()
 
         pair_scales[exclusions_1d] = exclusion_scales.squeeze(-1)
 

--- a/smee/potentials/valence.py
+++ b/smee/potentials/valence.py
@@ -4,6 +4,7 @@ import torch
 
 import smee.geometry
 import smee.potentials
+import smee.utils
 
 _EPSILON = 1.0e-8
 
@@ -32,7 +33,9 @@ def compute_harmonic_bond_energy(
     """
 
     if len(atom_indices) == 0:
-        return torch.zeros(1 if conformer.ndim == 2 else (conformer.shape[0],))
+        return smee.utils.zeros_like(
+            1 if conformer.ndim == 2 else (conformer.shape[0],), other=parameters
+        )
 
     _, distances = smee.geometry.compute_bond_vectors(conformer, atom_indices)
 
@@ -63,7 +66,9 @@ def compute_harmonic_angle_energy(
     """
 
     if len(atom_indices) == 0:
-        return torch.zeros(1 if conformer.ndim == 2 else (conformer.shape[0],))
+        return smee.utils.zeros_like(
+            1 if conformer.ndim == 2 else (conformer.shape[0],), other=parameters
+        )
 
     angles = smee.geometry.compute_angles(conformer, atom_indices)
 
@@ -94,7 +99,9 @@ def _compute_cosine_torsion_energy(
     """
 
     if len(atom_indices) == 0:
-        return torch.zeros(1 if conformer.ndim == 2 else (conformer.shape[0],))
+        return smee.utils.zeros_like(
+            1 if conformer.ndim == 2 else (conformer.shape[0],), other=parameters
+        )
 
     phi = smee.geometry.compute_dihedrals(conformer, atom_indices)
 

--- a/smee/tests/ff/test_nonbonded.py
+++ b/smee/tests/ff/test_nonbonded.py
@@ -18,7 +18,7 @@ def test_convert_electrostatics_am1bcc(ethanol, ethanol_interchange):
     assert potential.type == "Electrostatics"
     assert potential.fn == "coul"
 
-    expected_attributes = torch.tensor([0.0, 0.0, 5.0 / 6.0, 1.0])
+    expected_attributes = torch.tensor([0.0, 0.0, 5.0 / 6.0, 1.0], dtype=torch.float64)
     assert torch.allclose(potential.attributes, expected_attributes)
     assert potential.attribute_cols == (
         "scale_12",
@@ -40,7 +40,8 @@ def test_convert_electrostatics_am1bcc(ethanol, ethanol_interchange):
 
     assert parameter_map.assignment_matrix.shape == (ethanol.n_atoms, ethanol.n_atoms)
     assert torch.allclose(
-        parameter_map.assignment_matrix.to_dense(), torch.eye(ethanol.n_atoms)
+        parameter_map.assignment_matrix.to_dense(),
+        torch.eye(ethanol.n_atoms, dtype=torch.float64),
     )
 
     n_expected_exclusions = 36
@@ -117,8 +118,10 @@ def test_convert_electrostatics_v_site():
     assert potential.parameter_keys == expected_keys
     assert potential.parameters.shape == (4, 1)
 
-    expected_parameters = torch.tensor([[-0.75], [0.25], [-0.25], [0.5]])
-    assert torch.allclose(potential.parameters.float(), expected_parameters)
+    expected_parameters = torch.tensor(
+        [[-0.75], [0.25], [-0.25], [0.5]], dtype=torch.float64
+    )
+    assert torch.allclose(potential.parameters, expected_parameters)
 
     assert len(parameter_maps) == 1
     parameter_map = parameter_maps[0]
@@ -131,7 +134,8 @@ def test_convert_electrostatics_v_site():
             [0.0, 1.0, 0.0, -1.0],
             [1.0, 0.0, -1.0, 0.0],
             [0.0, 0.0, 1.0, 1.0],
-        ]
+        ],
+        dtype=torch.float64,
     )
     assert torch.allclose(
         parameter_map.assignment_matrix.to_dense(), expected_assignment_matrix
@@ -141,7 +145,7 @@ def test_convert_electrostatics_v_site():
     assert parameter_map.exclusions.shape == (n_expected_exclusions, 2)
     assert parameter_map.exclusion_scale_idxs.shape == (n_expected_exclusions, 1)
 
-    expected_exclusions = torch.tensor([[0, 1], [2, 1], [0, 2]])
+    expected_exclusions = torch.tensor([[0, 1], [2, 1], [0, 2]], dtype=torch.long)
     assert torch.allclose(parameter_map.exclusions, expected_exclusions)
 
     expected_scales = torch.zeros((n_expected_exclusions, 1), dtype=torch.long)

--- a/smee/tests/test_geometry.py
+++ b/smee/tests/test_geometry.py
@@ -303,7 +303,8 @@ def test_build_v_site_coordinate_frames():
             [+0.0, +0.0, +0.0],
             [-1.0, +0.0, +1.0],
             [-1.0, +0.0, -1.0],
-        ]
+        ],
+        dtype=torch.float64,
     ).unsqueeze(0)
 
     force_field = smee.ff.TensorForceField(
@@ -338,7 +339,8 @@ def test_build_v_site_coordinate_frames():
             [[-1.0, +0.0, +0.0], [-1.0, +0.0, +0.0]],
             [[+0.0, +0.0, +1.0], [+0.0, +0.0, -1.0]],
             [[+0.0, +1.0, +0.0], [+0.0, -1.0, +0.0]],
-        ]
+        ],
+        dtype=torch.float64,
     ).unsqueeze(0)
 
     assert actual_coord_frames.shape == expected_coord_frames.shape
@@ -353,12 +355,13 @@ def test_convert_v_site_coords():
             [[+1.0, +0.0, +0.0]],
             [[+0.0, +1.0, +0.0]],
             [[+0.0, +0.0, +1.0]],
-        ]
+        ],
+        dtype=torch.float64,
     ).unsqueeze(0)
 
     actual_coords = _convert_v_site_coords(local_frame_coords, local_coord_frames)
     expected_coords = torch.tensor(
-        [[0.5, 0.5, 1.0 / torch.sqrt(torch.tensor(2.0))]]
+        [[0.5, 0.5, 1.0 / torch.sqrt(torch.tensor(2.0))]], dtype=torch.float64
     ).unsqueeze(0)
 
     assert actual_coords.shape == expected_coords.shape
@@ -390,7 +393,7 @@ def test_compute_v_site_coords(smiles, v_site_force_field):
     v_site_coords = compute_v_site_coords(topology.v_sites, conformer, force_field)
 
     assert v_site_coords.shape == openmm_v_site_coords.shape
-    assert torch.allclose(v_site_coords, openmm_v_site_coords.float(), atol=1e-5)
+    assert torch.allclose(v_site_coords, openmm_v_site_coords, atol=1e-5)
 
 
 def test_compute_v_site_coords_batched(v_site_force_field):
@@ -400,7 +403,8 @@ def test_compute_v_site_coords_batched(v_site_force_field):
         [
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-        ]
+        ],
+        dtype=torch.float64,
     )
 
     interchange = _apply_v_site_force_field(molecule, conformers[0], v_site_force_field)
@@ -419,7 +423,7 @@ def test_compute_v_site_coords_batched(v_site_force_field):
     v_site_coords = compute_v_site_coords(topology.v_sites, conformers, force_field)
 
     assert v_site_coords.shape == openmm_v_site_coords.shape
-    assert torch.allclose(v_site_coords, openmm_v_site_coords.float(), atol=1e-5)
+    assert torch.allclose(v_site_coords, openmm_v_site_coords, atol=1e-5)
 
 
 @pytest.mark.parametrize(

--- a/smee/tests/test_utils.py
+++ b/smee/tests/test_utils.py
@@ -144,3 +144,38 @@ def test_find_exclusions_v_sites():
         (4, 3): "scale_14",
         (5, 3): "scale_12",
     }
+
+
+def test_ones_like():
+    expected_size = (4, 5)
+    expected_type = torch.float16
+
+    other = torch.tensor([1, 2, 3], dtype=expected_type, device="cpu")
+    tensor = smee.utils.ones_like(expected_size, other)
+
+    assert tensor.dtype == expected_type
+    assert tensor.shape == expected_size
+    assert torch.allclose(tensor, torch.tensor(1.0, dtype=expected_type))
+
+
+def test_zeros_like():
+    expected_size = (4, 5)
+    expected_type = torch.float16
+
+    other = torch.tensor([1, 2, 3], dtype=expected_type, device="cpu")
+    tensor = smee.utils.zeros_like(expected_size, other)
+
+    assert tensor.dtype == expected_type
+    assert tensor.shape == expected_size
+    assert torch.allclose(tensor, torch.tensor(0.0, dtype=expected_type))
+
+
+def test_tensor_like():
+    expected_type = torch.float16
+    expected_data = [[3.0], [2.0], [1.0]]
+
+    other = torch.tensor([], dtype=expected_type, device="cpu")
+    tensor = smee.utils.tensor_like(expected_data, other)
+
+    assert tensor.dtype == expected_type
+    assert torch.allclose(tensor, torch.tensor(expected_data, dtype=expected_type))

--- a/smee/utils.py
+++ b/smee/utils.py
@@ -3,9 +3,13 @@ import typing
 
 import networkx
 import openff.toolkit
+import torch
 
 if typing.TYPE_CHECKING:
     import smee.ff
+
+
+_size = torch.Size | list[int] | tuple[int, ...]
 
 
 def find_exclusions(
@@ -68,3 +72,18 @@ def find_exclusions(
                 v_site_exclusions[(pair[0], v_site_idx)] = scale
 
     return {**exclusions, **v_site_exclusions}
+
+
+def ones_like(size: _size, other: torch.Tensor) -> torch.Tensor:
+    """Create a tensor of ones with the same device and type as another tensor."""
+    return torch.ones(size, dtype=other.dtype, device=other.device)
+
+
+def zeros_like(size: _size, other: torch.Tensor) -> torch.Tensor:
+    """Create a tensor of zeros with the same device and type as another tensor."""
+    return torch.zeros(size, dtype=other.dtype, device=other.device)
+
+
+def tensor_like(data: typing.Any, other: torch.Tensor) -> torch.Tensor:
+    """Create a tensor with the same device and type as another tensor."""
+    return torch.tensor(data, dtype=other.dtype, device=other.device)


### PR DESCRIPTION
## Description

This PR swaps most tensors to be created as either float64 or long by default, rather than a mix of single and double precision.

## Status
- [X] Ready to go