### PR TITLE
Store enough extra info to convert to OpenMM

### DIFF
--- a/smee/ff/nonbonded.py
+++ b/smee/ff/nonbonded.py
@@ -46,7 +46,7 @@ def convert_nonbonded_handlers(
         v_site_maps: The virtual site maps associated with each handler.
         parameter_cols: The ordering of the parameter array columns.
         attribute_cols: The handler attributes to include in the potential *in addition*
-            to the intr-amolecular scaling factors.
+            to the intra-molecular scaling factors.
 
     Returns:
         The potential containing tensors of the parameter values, and a list of
@@ -115,7 +115,8 @@ def convert_nonbonded_handlers(
         exclusion_to_scale = smee.utils.find_exclusions(topology, v_site_map)
         exclusions = torch.tensor([*exclusion_to_scale])
         exclusion_scale_idxs = torch.tensor(
-            [[attribute_to_idx[scale]] for scale in exclusion_to_scale.values()]
+            [[attribute_to_idx[scale]] for scale in exclusion_to_scale.values()],
+            dtype=torch.int64,
         )
 
         parameter_map = smee.ff.NonbondedParameterMap(
@@ -137,6 +138,8 @@ def convert_nonbonded_handlers(
         "scale_13": _UNITLESS,
         "scale_14": _UNITLESS,
         "scale_15": _UNITLESS,
+        "cutoff": _ANGSTROM,
+        "switch_width": _ANGSTROM,
     },
 )
 def convert_vdw(
@@ -152,7 +155,12 @@ def convert_vdw(
         raise NotImplementedError("only Lorentz-Berthelot mixing rules are supported.")
 
     return convert_nonbonded_handlers(
-        handlers, "vdW", topologies, v_site_maps, ("epsilon", "sigma")
+        handlers,
+        "vdW",
+        topologies,
+        v_site_maps,
+        ("epsilon", "sigma"),
+        ("cutoff", "switch_width"),
     )
 
 
@@ -204,6 +212,7 @@ def _make_v_site_electrostatics_compatible(handlers: list[_ElectrostaticParamete
         "scale_13": _UNITLESS,
         "scale_14": _UNITLESS,
         "scale_15": _UNITLESS,
+        "cutoff": _ANGSTROM,
     },
 )
 def convert_electrostatics(
@@ -215,5 +224,5 @@ def convert_electrostatics(
     _make_v_site_electrostatics_compatible(handlers)
 
     return convert_nonbonded_handlers(
-        handlers, "Electrostatics", topologies, v_site_maps, ("charge",)
+        handlers, "Electrostatics", topologies, v_site_maps, ("charge",), ("cutoff",)
     )

--- a/smee/tests/conftest.py
+++ b/smee/tests/conftest.py
@@ -46,7 +46,7 @@ def ethanol_interchange(ethanol, default_force_field) -> openff.interchange.Inte
 
 @pytest.fixture(scope="module")
 def formaldehyde() -> openff.toolkit.Molecule:
-    """Returns an OpenFF formaldehyde molecule with a fixed atom order.."""
+    """Returns an OpenFF formaldehyde molecule with a fixed atom order."""
 
     return openff.toolkit.Molecule.from_mapped_smiles("[H:3][C:1](=[O:2])[H:4]")
 

--- a/smee/tests/ff/test_ff.py
+++ b/smee/tests/ff/test_ff.py
@@ -8,6 +8,7 @@ from smee.ff._ff import (
     _CONVERTERS,
     _DEFAULT_UNITS,
     VSiteMap,
+    _convert_topology,
     convert_handlers,
     convert_interchange,
     parameter_converter,
@@ -53,6 +54,35 @@ def test_convert_handler(ethanol, ethanol_interchange, mocker):
         handlers, topologies=topologies, v_site_maps=v_site_maps
     )
     assert result == mock_result
+
+
+def test_convert_topology(formaldehyde, mocker):
+    parameters = mocker.MagicMock()
+    v_sites = VSiteMap([], {}, torch.tensor([]))
+
+    topology = _convert_topology(formaldehyde, parameters, v_sites)
+
+    assert topology.n_atoms == 4
+    assert topology.n_bonds == 3
+
+    expected_atomic_nums = torch.tensor([6, 8, 1, 1])
+    expected_formal_charges = torch.tensor([0, 0, 0, 0])
+
+    expected_bond_idxs = torch.tensor([[0, 1], [0, 2], [0, 3]])
+    expected_bond_orders = torch.tensor([2, 1, 1])
+
+    assert topology.atomic_nums.shape == expected_atomic_nums.shape
+    assert torch.allclose(topology.atomic_nums, expected_atomic_nums)
+    assert topology.formal_charges.shape == expected_formal_charges.shape
+    assert torch.allclose(topology.formal_charges, expected_formal_charges)
+
+    assert topology.bond_idxs.shape == expected_bond_idxs.shape
+    assert torch.allclose(topology.bond_idxs, expected_bond_idxs)
+    assert topology.bond_orders.shape == expected_bond_orders.shape
+    assert torch.allclose(topology.bond_orders, expected_bond_orders)
+
+    assert topology.parameters == parameters
+    assert topology.v_sites == v_sites
 
 
 def test_convert_interchange():

--- a/smee/tests/ff/test_nonbonded.py
+++ b/smee/tests/ff/test_nonbonded.py
@@ -18,13 +18,16 @@ def test_convert_electrostatics_am1bcc(ethanol, ethanol_interchange):
     assert potential.type == "Electrostatics"
     assert potential.fn == "coul"
 
-    expected_attributes = torch.tensor([0.0, 0.0, 5.0 / 6.0, 1.0], dtype=torch.float64)
+    expected_attributes = torch.tensor(
+        [0.0, 0.0, 5.0 / 6.0, 1.0, 9.0], dtype=torch.float64
+    )
     assert torch.allclose(potential.attributes, expected_attributes)
     assert potential.attribute_cols == (
         "scale_12",
         "scale_13",
         "scale_14",
         "scale_15",
+        "cutoff",
     )
 
     assert potential.parameter_cols == ("charge",)


### PR DESCRIPTION
## Description

This PR extends the tensor topology object to also track atom and bond information, and now stores the cutoff and switch width attributes of non-bonded handlers (even if they are not used...)

This will allow OpenMM system objects (and in future perhaps even full OFF topology and molecules) to be created from the tensor representations.

## Status
- [X] Ready to go