### PR TITLE
Bump to interchange 0.3.15

### DIFF
--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -11,7 +11,7 @@ dependencies:
   # Core packages
   - openff-units
   - openff-toolkit-base >=0.9.2
-  - openff-interchange-base >=0.3.14
+  - openff-interchange-base >=0.3.15
 
   - pytorch-cpu
   - pydantic

--- a/smee/ff/_ff.py
+++ b/smee/ff/_ff.py
@@ -5,21 +5,12 @@ import typing
 
 import openff.interchange.components.potentials
 import openff.interchange.models
-import openff.interchange.smirnoff._base
-import openff.interchange.smirnoff._valence
-import openff.interchange.smirnoff._virtual_sites
+import openff.interchange.smirnoff
 import openff.toolkit
 import openff.units
 import torch
 
 import smee.geometry
-
-_VSiteParameters = (
-    openff.interchange.smirnoff._virtual_sites.SMIRNOFFVirtualSiteCollection
-)
-_ConstraintParameters = (
-    openff.interchange.smirnoff._valence.SMIRNOFFConstraintCollection
-)
 
 _CONVERTERS = {}
 _DEFAULT_UNITS = {}
@@ -243,7 +234,7 @@ def _get_value(
 
 
 def _handlers_to_potential(
-    handlers: list[openff.interchange.smirnoff._base.SMIRNOFFCollection],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFCollection],
     handler_type: str,
     parameter_cols: tuple[str, ...],
     attribute_cols: tuple[str, ...] | None,
@@ -310,7 +301,7 @@ def _handlers_to_potential(
 
 
 def _convert_v_sites(
-    handlers: list[_VSiteParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFVirtualSiteCollection],
     topologies: list[openff.toolkit.Topology],
 ) -> tuple[TensorVSites, list[VSiteMap | None]]:
     handler_types = {handler.type for handler in handlers}
@@ -393,7 +384,7 @@ def _convert_v_sites(
 
 
 def _convert_constraints(
-    handlers: list[openff.interchange.smirnoff._base.SMIRNOFFCollection],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFConstraintCollection],
 ) -> list[TensorConstraints | None]:
     handler_types = {handler.type for handler in handlers}
     assert handler_types == {"Constraints"}, "invalid handler types found"
@@ -426,7 +417,7 @@ def _convert_constraints(
 
 
 def convert_handlers(
-    handlers: list[openff.interchange.smirnoff._base.SMIRNOFFCollection],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFCollection],
     topologies: list[openff.toolkit.Topology],
     v_site_maps: list[VSiteMap | None] | None = None,
 ) -> tuple[TensorPotential, list[ParameterMap]]:

--- a/smee/ff/nonbonded.py
+++ b/smee/ff/nonbonded.py
@@ -4,19 +4,12 @@ import copy
 
 import openff.interchange.components.potentials
 import openff.interchange.models
-import openff.interchange.smirnoff._base
-import openff.interchange.smirnoff._nonbonded
 import openff.toolkit
 import openff.units
 import torch
 
 import smee.ff
 import smee.utils
-
-_VDWParameters = openff.interchange.smirnoff._nonbonded.SMIRNOFFvdWCollection
-_ElectrostaticParameters = (
-    openff.interchange.smirnoff._nonbonded.SMIRNOFFElectrostaticsCollection
-)
 
 _UNITLESS = openff.units.unit.dimensionless
 _ANGSTROM = openff.units.unit.angstrom
@@ -26,7 +19,7 @@ _ELEMENTARY_CHARGE = openff.units.unit.elementary_charge
 
 
 def convert_nonbonded_handlers(
-    handlers: list[openff.interchange.smirnoff._base.SMIRNOFFCollection],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFCollection],
     handler_type: str,
     topologies: list[openff.toolkit.Topology],
     v_site_maps: list[smee.ff.VSiteMap | None],
@@ -61,11 +54,8 @@ def convert_nonbonded_handlers(
         handlers,
         handler_type,
         parameter_cols,
-        ("scale_13", "scale_14", "scale_15", *attribute_cols),
+        ("scale_12", "scale_13", "scale_14", "scale_15", *attribute_cols),
     )
-
-    potential.attribute_cols = ("scale_12", *potential.attribute_cols)
-    potential.attributes = torch.cat([torch.tensor([0.0]), potential.attributes])
 
     parameter_key_to_idx = {
         parameter_key: i for i, parameter_key in enumerate(potential.parameter_keys)
@@ -143,7 +133,7 @@ def convert_nonbonded_handlers(
     },
 )
 def convert_vdw(
-    handlers: list[_VDWParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFvdWCollection],
     topologies: list[openff.toolkit.Topology],
     v_site_maps: list[smee.ff.VSiteMap | None],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.NonbondedParameterMap]]:
@@ -164,7 +154,9 @@ def convert_vdw(
     )
 
 
-def _make_v_site_electrostatics_compatible(handlers: list[_ElectrostaticParameters]):
+def _make_v_site_electrostatics_compatible(
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFElectrostaticsCollection],
+):
     """Attempts to make electrostatic potentials associated with virtual sites more
     consistent with other parameters so that they can be more easily converted to
     tensors.
@@ -216,7 +208,7 @@ def _make_v_site_electrostatics_compatible(handlers: list[_ElectrostaticParamete
     },
 )
 def convert_electrostatics(
-    handlers: list[_ElectrostaticParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFElectrostaticsCollection],
     topologies: list[openff.toolkit.Topology],
     v_site_maps: list[smee.ff.VSiteMap | None],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.NonbondedParameterMap]]:

--- a/smee/ff/valence.py
+++ b/smee/ff/valence.py
@@ -1,15 +1,9 @@
 """Convert SMIRNOFF valence parameters into tensors."""
-import openff.interchange.smirnoff._base
-import openff.interchange.smirnoff._valence
+import openff.interchange.smirnoff
 import openff.units
 import torch
 
 import smee.ff
-
-_BondParameters = openff.interchange.smirnoff._base.SMIRNOFFCollection
-_AngleParameters = openff.interchange.smirnoff._base.SMIRNOFFCollection
-_ProperTorsionParameters = openff.interchange.smirnoff._base.SMIRNOFFCollection
-_ImproperTorsionParameters = openff.interchange.smirnoff._base.SMIRNOFFCollection
 
 _UNITLESS = openff.units.unit.dimensionless
 _ANGSTROM = openff.units.unit.angstrom
@@ -18,7 +12,7 @@ _KCAL_PER_MOL = openff.units.unit.kilocalories / openff.units.unit.mole
 
 
 def convert_valence_handlers(
-    handlers: list[_BondParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFCollection],
     handler_type: str,
     parameter_cols: tuple[str, ...],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.ValenceParameterMap]]:
@@ -68,7 +62,7 @@ def convert_valence_handlers(
     "Bonds", {"k": _KCAL_PER_MOL / _ANGSTROM**2, "length": _ANGSTROM}
 )
 def convert_bonds(
-    handlers: list[openff.interchange.smirnoff._valence.SMIRNOFFBondCollection],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFBondCollection],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.ValenceParameterMap]]:
     return convert_valence_handlers(handlers, "Bonds", ("k", "length"))
 
@@ -77,7 +71,7 @@ def convert_bonds(
     "Angles", {"k": _KCAL_PER_MOL / _RADIANS**2, "angle": _RADIANS}
 )
 def convert_angles(
-    handlers: list[_AngleParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFAngleCollection],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.ValenceParameterMap]]:
     return convert_valence_handlers(handlers, "Angles", ("k", "angle"))
 
@@ -92,7 +86,7 @@ def convert_angles(
     },
 )
 def convert_propers(
-    handlers: list[_ProperTorsionParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFProperTorsionCollection],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.ValenceParameterMap]]:
     return convert_valence_handlers(
         handlers, "ProperTorsions", ("k", "periodicity", "phase", "idivf")
@@ -109,7 +103,7 @@ def convert_propers(
     },
 )
 def convert_impropers(
-    handlers: list[_ImproperTorsionParameters],
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFImproperTorsionCollection],
 ) -> tuple[smee.ff.TensorPotential, list[smee.ff.ValenceParameterMap]]:
     return convert_valence_handlers(
         handlers, "ImproperTorsions", ("k", "periodicity", "phase", "idivf")

--- a/smee/tests/potentials/test_potentials.py
+++ b/smee/tests/potentials/test_potentials.py
@@ -117,9 +117,8 @@ def test_compute_energy_v_sites():
     conformer = torch.vstack(
         [
             torch.tensor(conformer_a),
-            torch.zeros((1, 3)),  # interchange for now interleaves v-sites
             torch.tensor(conformer_b + numpy.array([[3.0, 0.0, 0.0]])),
-            torch.zeros((1, 3)),
+            torch.zeros((2, 3)),
         ]
     )
 
@@ -131,10 +130,6 @@ def test_compute_energy_v_sites():
     force_field, topologies = convert_interchange(interchange)
 
     energy_openmm = compute_openmm_energy(interchange, conformer)
-    energy_smee = compute_energy(
-        topologies[0].parameters,
-        conformer[[0, 1, 2, 4, 5, 6, 3, 7], :],
-        force_field,
-    )
+    energy_smee = compute_energy(topologies[0].parameters, conformer, force_field)
 
     assert torch.isclose(energy_smee, energy_openmm)


### PR DESCRIPTION
## Description

This PR upgrades to `openff-interchange >=0.3.15` which contains a number of QoL improvements (no more private imports!, exposes `scale12`) and some bug fixes for v-sites.

Thanks @mattwthompson!

## Status
- [X] Ready to go