### PR TITLE
Add initial PME support

### DIFF
--- a/smee/converters/openmm.py
+++ b/smee/converters/openmm.py
@@ -100,7 +100,7 @@ def _convert_electrostatics_potential(
         for _ in range(n_copies):
             for charge in parameters:
                 force.addParticle(
-                    charge * openmm.unit.elementary_charge,
+                    charge.detach() * openmm.unit.elementary_charge,
                     1.0 * _ANGSTROM,
                     0.0 * _KCAL_PER_MOL,
                 )

--- a/smee/potentials/__init__.py
+++ b/smee/potentials/__init__.py
@@ -1,7 +1,6 @@
 """Evaluate the potential energy of parameterized topologies."""
 
 from smee.potentials._potentials import (
-    broadcast_exclusions,
     broadcast_parameters,
     compute_energy,
     compute_energy_potential,
@@ -9,7 +8,6 @@ from smee.potentials._potentials import (
 )
 
 __all__ = [
-    "broadcast_exclusions",
     "broadcast_parameters",
     "compute_energy",
     "compute_energy_potential",

--- a/smee/potentials/_potentials.py
+++ b/smee/potentials/_potentials.py
@@ -49,63 +49,12 @@ def broadcast_parameters(
                     @ potential.parameters
                 )[None, :, :],
                 (n_copies, topology.n_atoms, potential.parameters.shape[-1]),
-            ).reshape(-1, 2)
+            ).reshape(-1, potential.parameters.shape[-1])
             for topology, n_copies in zip(system.topologies, system.n_copies)
         ]
     )
 
     return parameters
-
-
-def broadcast_exclusions(
-    system: smee.TensorSystem, potential: smee.TensorPotential
-) -> torch.Tensor:
-    """Returns the scale factor for each interaction in the full system by broadcasting
-    and stacking the exclusions of each topology.
-
-    Args:
-        system: The system.
-        potential: The potential containing the scale factors to broadcast.
-
-    Returns:
-        The parameters for the full system with
-        ``shape=(n_particles * (n_particles - 1) / 2,)``.
-    """
-
-    n_particles = system.n_particles
-    n_pairs = (n_particles * (n_particles - 1)) // 2
-
-    pair_scales = smee.utils.ones_like(n_pairs, other=potential.parameters)
-
-    idx_offset = 0
-
-    for topology, n_copies in zip(system.topologies, system.n_copies):
-        exclusion_offset = idx_offset + torch.arange(n_copies) * topology.n_particles
-
-        exclusion_idxs = topology.parameters[potential.type].exclusions
-        exclusion_idxs = exclusion_offset[:, None, None] + exclusion_idxs[None, :, :]
-
-        exclusion_scales = potential.attributes[
-            topology.parameters[potential.type].exclusion_scale_idxs
-        ]
-        exclusion_scales = torch.broadcast_to(
-            exclusion_scales, (n_copies, *exclusion_scales.shape)
-        )
-
-        exclusion_idxs = exclusion_idxs.reshape(-1, 2)
-        exclusion_scales = exclusion_scales.reshape(-1)
-
-        if len(exclusion_idxs) > 0:
-            exclusion_idxs, _ = exclusion_idxs.sort(dim=1)  # ensure upper triangle
-
-            pair_idxs = smee.utils.to_upper_tri_idx(
-                exclusion_idxs[:, 0], exclusion_idxs[:, 1], n_particles
-            )
-            pair_scales[pair_idxs] = exclusion_scales
-
-        idx_offset += n_copies * topology.n_particles
-
-    return pair_scales
 
 
 def compute_energy_potential(

--- a/smee/tests/potentials/conftest.py
+++ b/smee/tests/potentials/conftest.py
@@ -1,97 +1,34 @@
-import openff.interchange.models
-import openff.units
+import copy
+
+import openmm.unit
 import pytest
 import torch
 
-import smee.potentials
+import smee.mm
 import smee.tests.utils
-import smee.utils
 
 
-@pytest.fixture()
-def mock_lj_potential() -> smee.TensorPotential:
-    return smee.TensorPotential(
-        type="vdW",
-        fn="LJ",
-        parameters=torch.tensor([[0.1, 1.1], [0.2, 2.1], [0.3, 3.1]]),
-        parameter_keys=[
-            openff.interchange.models.PotentialKey(id="[#1:1]"),
-            openff.interchange.models.PotentialKey(id="[#6:1]"),
-            openff.interchange.models.PotentialKey(id="[#8:1]"),
-        ],
-        parameter_cols=("epsilon", "sigma"),
-        parameter_units=(
-            openff.units.unit.kilojoule_per_mole,
-            openff.units.unit.angstrom,
-        ),
-        attributes=torch.tensor([0.0, 0.0, 0.5, 1.0, 9.0, 2.0]),
-        attribute_cols=(
-            "scale_12",
-            "scale_13",
-            "scale_14",
-            "scale_15",
-            "cutoff",
-            "switch_width",
-        ),
-        attribute_units=(
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.angstrom,
-            openff.units.unit.angstrom,
+@pytest.fixture(scope="module")
+def _etoh_water_system() -> (
+    tuple[smee.TensorSystem, smee.TensorForceField, torch.Tensor, torch.Tensor]
+):
+    system, force_field = smee.tests.utils.system_from_smiles(["CCO", "O"], [67, 123])
+    coords, box_vectors = smee.mm.generate_system_coords(system)
+
+    return (
+        system,
+        force_field,
+        torch.tensor(coords.value_in_unit(openmm.unit.angstrom), dtype=torch.float32),
+        torch.tensor(
+            box_vectors.value_in_unit(openmm.unit.angstrom), dtype=torch.float32
         ),
     )
 
 
 @pytest.fixture()
-def mock_methane_top() -> smee.TensorTopology:
-    methane_top = smee.tests.utils.topology_from_smiles("C")
-    methane_top.parameters = {
-        "vdW": smee.NonbondedParameterMap(
-            assignment_matrix=torch.tensor(
-                [
-                    [0.0, 1.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                ]
-            ).to_sparse(),
-            exclusions=torch.tensor(
-                [
-                    [0, 1],
-                    [0, 2],
-                    [0, 3],
-                    [0, 4],
-                    [1, 2],
-                    [1, 3],
-                    [1, 4],
-                    [2, 3],
-                    [2, 4],
-                    [3, 4],
-                ]
-            ),
-            exclusion_scale_idxs=torch.tensor([[0] * 4 + [1] * 6]),
-        )
-    }
-    return methane_top
+def etoh_water_system(
+    _etoh_water_system,
+) -> tuple[smee.TensorSystem, smee.TensorForceField, torch.Tensor, torch.Tensor]:
+    """Creates a system of ethanol and water."""
 
-
-@pytest.fixture()
-def mock_water_top() -> smee.TensorTopology:
-    methane_top = smee.tests.utils.topology_from_smiles("O")
-    methane_top.parameters = {
-        "vdW": smee.NonbondedParameterMap(
-            assignment_matrix=torch.tensor(
-                [
-                    [0.0, 0.0, 1.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                ]
-            ).to_sparse(),
-            exclusions=torch.tensor([[0, 1], [0, 2], [1, 2]]),
-            exclusion_scale_idxs=torch.tensor([[0], [0], [1]]),
-        )
-    }
-    return methane_top
+    return copy.deepcopy(_etoh_water_system)

--- a/smee/tests/potentials/conftest.py
+++ b/smee/tests/potentials/conftest.py
@@ -1,0 +1,97 @@
+import openff.interchange.models
+import openff.units
+import pytest
+import torch
+
+import smee.potentials
+import smee.tests.utils
+import smee.utils
+
+
+@pytest.fixture()
+def mock_lj_potential() -> smee.TensorPotential:
+    return smee.TensorPotential(
+        type="vdW",
+        fn="LJ",
+        parameters=torch.tensor([[0.1, 1.1], [0.2, 2.1], [0.3, 3.1]]),
+        parameter_keys=[
+            openff.interchange.models.PotentialKey(id="[#1:1]"),
+            openff.interchange.models.PotentialKey(id="[#6:1]"),
+            openff.interchange.models.PotentialKey(id="[#8:1]"),
+        ],
+        parameter_cols=("epsilon", "sigma"),
+        parameter_units=(
+            openff.units.unit.kilojoule_per_mole,
+            openff.units.unit.angstrom,
+        ),
+        attributes=torch.tensor([0.0, 0.0, 0.5, 1.0, 9.0, 2.0]),
+        attribute_cols=(
+            "scale_12",
+            "scale_13",
+            "scale_14",
+            "scale_15",
+            "cutoff",
+            "switch_width",
+        ),
+        attribute_units=(
+            openff.units.unit.dimensionless,
+            openff.units.unit.dimensionless,
+            openff.units.unit.dimensionless,
+            openff.units.unit.dimensionless,
+            openff.units.unit.angstrom,
+            openff.units.unit.angstrom,
+        ),
+    )
+
+
+@pytest.fixture()
+def mock_methane_top() -> smee.TensorTopology:
+    methane_top = smee.tests.utils.topology_from_smiles("C")
+    methane_top.parameters = {
+        "vdW": smee.NonbondedParameterMap(
+            assignment_matrix=torch.tensor(
+                [
+                    [0.0, 1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                ]
+            ).to_sparse(),
+            exclusions=torch.tensor(
+                [
+                    [0, 1],
+                    [0, 2],
+                    [0, 3],
+                    [0, 4],
+                    [1, 2],
+                    [1, 3],
+                    [1, 4],
+                    [2, 3],
+                    [2, 4],
+                    [3, 4],
+                ]
+            ),
+            exclusion_scale_idxs=torch.tensor([[0] * 4 + [1] * 6]),
+        )
+    }
+    return methane_top
+
+
+@pytest.fixture()
+def mock_water_top() -> smee.TensorTopology:
+    methane_top = smee.tests.utils.topology_from_smiles("O")
+    methane_top.parameters = {
+        "vdW": smee.NonbondedParameterMap(
+            assignment_matrix=torch.tensor(
+                [
+                    [0.0, 0.0, 1.0],
+                    [1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                ]
+            ).to_sparse(),
+            exclusions=torch.tensor([[0, 1], [0, 2], [1, 2]]),
+            exclusion_scale_idxs=torch.tensor([[0], [0], [1]]),
+        )
+    }
+    return methane_top

--- a/smee/tests/potentials/test_potentials.py
+++ b/smee/tests/potentials/test_potentials.py
@@ -10,96 +10,7 @@ import torch
 
 import smee.converters
 import smee.tests.utils
-from smee.potentials import broadcast_exclusions, broadcast_parameters, compute_energy
-
-
-@pytest.fixture()
-def mock_lj_potential() -> smee.TensorPotential:
-    return smee.TensorPotential(
-        type="vdW",
-        fn="LJ",
-        parameters=torch.tensor([[0.1, 1.1], [0.2, 2.1], [0.3, 3.1]]),
-        parameter_keys=[
-            openff.interchange.models.PotentialKey(id="[#1:1]"),
-            openff.interchange.models.PotentialKey(id="[#6:1]"),
-            openff.interchange.models.PotentialKey(id="[#8:1]"),
-        ],
-        parameter_cols=("epsilon", "sigma"),
-        parameter_units=(
-            openff.units.unit.kilojoule_per_mole,
-            openff.units.unit.angstrom,
-        ),
-        attributes=torch.tensor([0.0, 0.0, 0.5, 1.0, 9.0, 2.0]),
-        attribute_cols=(
-            "scale_12",
-            "scale_13",
-            "scale_14",
-            "scale_15",
-            "cutoff",
-            "switch_width",
-        ),
-        attribute_units=(
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.dimensionless,
-            openff.units.unit.angstrom,
-            openff.units.unit.angstrom,
-        ),
-    )
-
-
-@pytest.fixture()
-def mock_methane_top() -> smee.TensorTopology:
-    methane_top = smee.tests.utils.topology_from_smiles("C")
-    methane_top.parameters = {
-        "vdW": smee.NonbondedParameterMap(
-            assignment_matrix=torch.tensor(
-                [
-                    [0.0, 1.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                ]
-            ).to_sparse(),
-            exclusions=torch.tensor(
-                [
-                    [0, 1],
-                    [0, 2],
-                    [0, 3],
-                    [0, 4],
-                    [1, 2],
-                    [1, 3],
-                    [1, 4],
-                    [2, 3],
-                    [2, 4],
-                    [3, 4],
-                ]
-            ),
-            exclusion_scale_idxs=torch.tensor([[0] * 4 + [1] * 6]),
-        )
-    }
-    return methane_top
-
-
-@pytest.fixture()
-def mock_water_top() -> smee.TensorTopology:
-    methane_top = smee.tests.utils.topology_from_smiles("O")
-    methane_top.parameters = {
-        "vdW": smee.NonbondedParameterMap(
-            assignment_matrix=torch.tensor(
-                [
-                    [0.0, 0.0, 1.0],
-                    [1.0, 0.0, 0.0],
-                    [1.0, 0.0, 0.0],
-                ]
-            ).to_sparse(),
-            exclusions=torch.tensor([[0, 1], [0, 2], [1, 2]]),
-            exclusion_scale_idxs=torch.tensor([[0], [0], [1]]),
-        )
-    }
-    return methane_top
+from smee.potentials import broadcast_parameters, compute_energy
 
 
 def test_broadcast_parameters(mock_lj_potential, mock_methane_top, mock_water_top):
@@ -121,50 +32,6 @@ def test_broadcast_parameters(mock_lj_potential, mock_methane_top, mock_water_to
     )
     assert parameters.shape == expected_parameters.shape
     assert torch.allclose(parameters, expected_parameters)
-
-
-def test_broadcast_exclusions(mock_lj_potential, mock_methane_top, mock_water_top):
-    mock_lj_potential.attributes = torch.tensor([0.01, 0.02, 0.5, 1.0, 9.0, 2.0])
-
-    system = smee.TensorSystem([mock_methane_top, mock_water_top], [2, 3], True)
-
-    scales = broadcast_exclusions(system, mock_lj_potential)
-
-    # fmt: off
-    expected_scale_matrix = torch.tensor(
-        [
-            [1.0, 0.01, 0.01, 0.01, 0.01] + [1.0] * (system.n_particles - 5),
-            [0.01, 1.0, 0.02, 0.02, 0.02] + [1.0] * (system.n_particles - 5),
-            [0.01, 0.02, 1.0, 0.02, 0.02] + [1.0] * (system.n_particles - 5),
-            [0.01, 0.02, 0.02, 1.0, 0.02] + [1.0] * (system.n_particles - 5),
-            [0.01, 0.02, 0.02, 0.02, 1.0] + [1.0] * (system.n_particles - 5),
-            #
-            [1.0] * 5 + [1.0, 0.01, 0.01, 0.01, 0.01] + [1.0] * (system.n_particles - 10),
-            [1.0] * 5 + [0.01, 1.0, 0.02, 0.02, 0.02] + [1.0] * (system.n_particles - 10),
-            [1.0] * 5 + [0.01, 0.02, 1.0, 0.02, 0.02] + [1.0] * (system.n_particles - 10),
-            [1.0] * 5 + [0.01, 0.02, 0.02, 1.0, 0.02] + [1.0] * (system.n_particles - 10),
-            [1.0] * 5 + [0.01, 0.02, 0.02, 0.02, 1.0] + [1.0] * (system.n_particles - 10),
-            #
-            [1.0] * 10 + [1.0, 0.01, 0.01] + [1.0] * (system.n_particles - 13),
-            [1.0] * 10 + [0.01, 1.0, 0.02] + [1.0] * (system.n_particles - 13),
-            [1.0] * 10 + [0.01, 0.02, 1.0] + [1.0] * (system.n_particles - 13),
-            #
-            [1.0] * 13 + [1.0, 0.01, 0.01] + [1.0] * (system.n_particles - 16),
-            [1.0] * 13 + [0.01, 1.0, 0.02] + [1.0] * (system.n_particles - 16),
-            [1.0] * 13 + [0.01, 0.02, 1.0] + [1.0] * (system.n_particles - 16),
-            #
-            [1.0] * 16 + [1.0, 0.01, 0.01],
-            [1.0] * 16 + [0.01, 1.0, 0.02],
-            [1.0] * 16 + [0.01, 0.02, 1.0],
-        ]
-    )
-    # fmt: on
-
-    i, j = torch.triu_indices(system.n_particles, system.n_particles, 1)
-    expected_scales = expected_scale_matrix[i, j]
-
-    assert scales.shape == expected_scales.shape
-    assert torch.allclose(scales, expected_scales)
 
 
 def place_v_sites(

--- a/smee/tests/potentials/test_potentials.py
+++ b/smee/tests/potentials/test_potentials.py
@@ -13,22 +13,23 @@ import smee.tests.utils
 from smee.potentials import broadcast_parameters, compute_energy
 
 
-def test_broadcast_parameters(mock_lj_potential, mock_methane_top, mock_water_top):
-    system = smee.TensorSystem([mock_methane_top, mock_water_top], [2, 3], True)
+def test_broadcast_parameters():
+    system, force_field = smee.tests.utils.system_from_smiles(["C", "O"], [2, 3])
+    vdw_potential = force_field.potentials_by_type["vdW"]
 
-    parameters = broadcast_parameters(system, mock_lj_potential)
+    methane_top, water_top = system.topologies
 
-    methane_parameters = (
-        mock_methane_top.parameters["vdW"].assignment_matrix
-        @ mock_lj_potential.parameters
+    parameters = broadcast_parameters(system, vdw_potential)
+
+    expected_methane_parameters = (
+        methane_top.parameters["vdW"].assignment_matrix @ vdw_potential.parameters
     )
-    water_parameters = (
-        mock_water_top.parameters["vdW"].assignment_matrix
-        @ mock_lj_potential.parameters
+    expected_water_parameters = (
+        water_top.parameters["vdW"].assignment_matrix @ vdw_potential.parameters
     )
 
     expected_parameters = torch.vstack(
-        [methane_parameters] * 2 + [water_parameters] * 3
+        [expected_methane_parameters] * 2 + [expected_water_parameters] * 3
     )
     assert parameters.shape == expected_parameters.shape
     assert torch.allclose(parameters, expected_parameters)


### PR DESCRIPTION
## Description

This PR adds initial (hidden) support for computing the Coulomb energy of a periodic system in a way that should be fully differentiable and GPU compatible using `NNPOps`. The main thing needed here was computing the 1-n terms with the correct scaling factor.

## TODO

- [x] Add tests for exception / exclusion broadcasting

## Status
- [x] Ready to go