### PR TITLE
Expose `NotEnoughSamplesError`

### DIFF
--- a/smee/mm/__init__.py
+++ b/smee/mm/__init__.py
@@ -2,7 +2,11 @@
 
 from smee.mm._config import GenerateCoordsConfig, MinimizationConfig, SimulationConfig
 from smee.mm._mm import generate_system_coords, simulate
-from smee.mm._ops import compute_ensemble_averages, reweight_ensemble_averages
+from smee.mm._ops import (
+    NotEnoughSamplesError,
+    compute_ensemble_averages,
+    reweight_ensemble_averages,
+)
 from smee.mm._reporters import TensorReporter, unpack_frames
 
 __all__ = [
@@ -12,6 +16,7 @@ __all__ = [
     "simulate",
     "GenerateCoordsConfig",
     "MinimizationConfig",
+    "NotEnoughSamplesError",
     "SimulationConfig",
     "TensorReporter",
     "unpack_frames",


### PR DESCRIPTION
## Description

This PR exposes the `NotEnoughSamplesError` raised while re-weighting, which was previously only expose in the private `_ops` module.

## Status
- [X] Ready to go