### PR TITLE
Fix re-weighting when du/dp is negative

### DIFF
--- a/smee/tests/mm/test_ops.py
+++ b/smee/tests/mm/test_ops.py
@@ -339,7 +339,7 @@ def test_reweight_ensemble_averages(mocker, tmp_path, mock_argon_tensors):
     )
 
     mock_columns = ["potential_energy", "volume", "density"]
-    mock_du_d_theta = (torch.tensor([[[9.0, 10.0], [11.0, 12.0]]]), None)
+    mock_du_d_theta = (torch.tensor([[[-9.0, 10.0], [11.0, -12.0]]]), None)
 
     mocker.patch(
         "smee.mm._ops._compute_observables",

--- a/smee/tests/test_utils.py
+++ b/smee/tests/test_utils.py
@@ -236,6 +236,24 @@ def test_logsumexp(a, b, dim, keepdim):
     assert torch.allclose(actual.double(), expected.double())
 
 
+def test_logsumexp_with_sign():
+    from scipy.special import logsumexp
+
+    a = torch.tensor([1.0, 2.0, 3.0])
+    b = torch.tensor(-2.0)
+
+    actual, actual_sign = smee.utils.logsumexp(a, -1, True, b, return_sign=True)
+    expected, expected_sign = torch.tensor(
+        logsumexp(a.numpy(), -1, b.numpy(), True, return_sign=True)
+    )
+
+    assert actual.shape == expected.shape
+    assert torch.allclose(actual.double(), expected.double())
+
+    assert actual_sign.shape == expected_sign.shape
+    assert torch.allclose(actual_sign.double(), expected_sign.double())
+
+
 @pytest.mark.parametrize("n", [7499, 7500, 7501])
 def test_to_upper_tri_idx(n):
     i, j = torch.triu_indices(n, n, 1)


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the re-weighted average of an observables would be NaN if du/dp is negative.

## Status
- [X] Ready to go