### PR TITLE
Fix v-site charge increment direction

### DIFF
--- a/smee/converters/openff/nonbonded.py
+++ b/smee/converters/openff/nonbonded.py
@@ -91,8 +91,8 @@ def convert_nonbonded_handlers(
                     mult_key = copy.deepcopy(parameter_key)
                     mult_key.mult = i
 
-                    assignment_map[atom_idx][parameter_key_to_idx[mult_key]] += -1.0
-                    assignment_map[v_site_idx][parameter_key_to_idx[mult_key]] += 1.0
+                    assignment_map[atom_idx][parameter_key_to_idx[mult_key]] += 1.0
+                    assignment_map[v_site_idx][parameter_key_to_idx[mult_key]] += -1.0
 
         assignment_matrix = torch.zeros(
             (n_particles, len(potential.parameters)), dtype=torch.float64

--- a/smee/converters/openmm.py
+++ b/smee/converters/openmm.py
@@ -403,6 +403,11 @@ def convert_to_openmm_topology(system: smee.TensorSystem) -> openmm.app.Topology
                 )
                 atoms[i] = omm_topology.addAtom(name, element, residue)
 
+            for i in range(topology.n_v_sites):
+                omm_topology.addAtom(
+                    "X", openmm.app.Element.getByAtomicNumber(82), residue
+                )
+
             for bond_idxs, bond_order in zip(topology.bond_idxs, topology.bond_orders):
                 idx_a, idx_b = int(bond_idxs[0]), int(bond_idxs[1])
 

--- a/smee/converters/openmm.py
+++ b/smee/converters/openmm.py
@@ -83,7 +83,7 @@ def _convert_lj_potential(
                     scale * eps * _KCAL_PER_MOL,
                 )
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
     return force
 
@@ -121,7 +121,7 @@ def _convert_electrostatics_potential(
                     0.0,
                 )
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
     return force
 
@@ -149,7 +149,7 @@ def _convert_bond_potential(
                     constant * _KCAL_PER_MOL / _ANGSTROM**2,
                 )
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
     return force
 
@@ -178,7 +178,7 @@ def _convert_angle_potential(
                     constant * _KCAL_PER_MOL / _RADIANS**2,
                 )
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
     return force
 
@@ -211,7 +211,7 @@ def _convert_torsion_potential(
                     constant / idivf * _KCAL_PER_MOL,
                 )
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
     return force
 
@@ -308,7 +308,7 @@ def _apply_constraints(omm_system: openmm.System, system: smee.TensorSystem):
             for (i, j), distance in zip(atom_idxs, topology.constraints.distances):
                 omm_system.addConstraint(i, j, distance * _ANGSTROM)
 
-            idx_offset += topology.n_atoms
+            idx_offset += topology.n_particles
 
 
 def convert_to_openmm_force(


### PR DESCRIPTION
## Description

This bug fixes a nasty bug whereby charges was transferred from the parent atom to the v-site, rather than the other way around. It further fixes issues creating OpenMM systems due to improve idx offsetting.

## Status
- [X] Ready to go