### PR TITLE
Add std error to MM ensemble avg outputs

### DIFF
--- a/examples/md-simulations.ipynb
+++ b/examples/md-simulations.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "markdown",
    "id": "aaf952cb344ca32d",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "# Ensemble Averages from MD Simulations\n",
@@ -26,10 +23,7 @@
      "end_time": "2023-11-08T12:44:39.088878928Z",
      "start_time": "2023-11-08T12:44:32.342740491Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [
     {
@@ -100,10 +94,7 @@
    "cell_type": "markdown",
    "id": "415cbefaa3d60c49",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "We will also flag that the vdW parameter gradients are required:"
@@ -118,10 +109,7 @@
      "end_time": "2023-11-08T12:44:39.103624993Z",
      "start_time": "2023-11-08T12:44:39.097640693Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -133,10 +121,7 @@
    "cell_type": "markdown",
    "id": "824dfd3f7f6916b3",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "We then define the full simulation boxes that we wish to simulate:"
@@ -151,10 +136,7 @@
      "end_time": "2023-11-08T12:44:39.383031948Z",
      "start_time": "2023-11-08T12:44:39.099505793Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -175,10 +157,7 @@
    "cell_type": "markdown",
    "id": "93a519affcb22db4",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "A tensor system is simply a wrapper around a set of topology objects that define parameters applied to individual molecules, and the number of copies of that topology that should be present similar to GROMACS topologies. The `is_periodic` flag indicates whether the system should be simulated in a periodic box.\n",
@@ -197,10 +176,7 @@
      "end_time": "2023-11-08T12:44:39.474284381Z",
      "start_time": "2023-11-08T12:44:39.387381350Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -248,10 +224,7 @@
    "cell_type": "markdown",
    "id": "9db4088f839c4265",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "We will further define a convenience function that will first simulate the system of interest (storing the trajectory in a temporary directory), and then compute ensemble averages over that trajectory:"
@@ -266,10 +239,7 @@
      "end_time": "2023-11-08T12:44:39.482417652Z",
      "start_time": "2023-11-08T12:44:39.478860928Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -313,19 +283,17 @@
     "        # having to worry about copying gradients between workers / processes.\n",
     "        import pathlib\n",
     "\n",
-    "        return smee.mm.compute_ensemble_averages(\n",
+    "        avgs, stds = smee.mm.compute_ensemble_averages(\n",
     "            system, force_field, pathlib.Path(tmp_path.name), temperature, pressure\n",
-    "        )"
+    "        )\n",
+    "        return avgs"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8d1fdb6973324d14",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "Computing the ensemble averages is then as simple as:"
@@ -340,10 +308,7 @@
      "end_time": "2023-11-08T12:44:40.364614982Z",
      "start_time": "2023-11-08T12:44:39.485185718Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -358,10 +323,7 @@
    "cell_type": "markdown",
    "id": "bcce5c83a564c59f",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "Each of the returned values is a dictionary of ensemble averages computed over the simulated production trajectory. This currently includes the potential energy, volume, and density of the system.\n",
@@ -378,10 +340,7 @@
      "end_time": "2023-11-08T12:44:40.369070019Z",
      "start_time": "2023-11-08T12:44:40.365546037Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -409,10 +368,7 @@
    "cell_type": "markdown",
    "id": "9bd6779012316898",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "and the gradient of this loss function with respect to the force field parameters can be computed through backpropagation:"
@@ -427,10 +383,7 @@
      "end_time": "2023-11-08T12:44:40.371248178Z",
      "start_time": "2023-11-08T12:44:40.370055198Z"
     },
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [

--- a/smee/mm/_ops.py
+++ b/smee/mm/_ops.py
@@ -294,18 +294,23 @@ class _EnsembleAverageOp(torch.autograd.Function):
             )
 
         avg_values = values.mean(dim=0)
+        avg_stds = [*values.std(dim=0)]
 
         ctx.beta = kwargs["beta"]
         ctx.n_theta = len(theta)
         ctx.columns = columns
         ctx.save_for_backward(*theta, *du_d_theta, values, avg_values)
 
-        return tuple([*avg_values, columns])
+        ctx.mark_non_differentiable(*avg_stds)
+
+        return tuple([*avg_values, *avg_stds, tuple(columns)])
 
     @staticmethod
     def backward(ctx, *grad_outputs):
         theta = ctx.saved_tensors[: ctx.n_theta]
         du_d_theta = ctx.saved_tensors[ctx.n_theta : 2 * ctx.n_theta]
+
+        grad_outputs = torch.stack(grad_outputs[: (len(grad_outputs) - 1) // 2])
 
         values = ctx.saved_tensors[-2]
         avg_values = ctx.saved_tensors[-1]
@@ -337,10 +342,10 @@ class _EnsembleAverageOp(torch.autograd.Function):
                 avg_output_du_d_theta_i - avg_du_d_theta_i_avg_output
             )
 
-            grads[i] = d_avg_output_d_theta_i @ torch.stack(grad_outputs[:-1])
+            grads[i] = d_avg_output_d_theta_i @ grad_outputs
 
         # we need to return one extra 'gradient' for kwargs.
-        return tuple([None] + grads + [None])
+        return tuple([None] + grads)
 
 
 class _ReweightAverageOp(torch.autograd.Function):
@@ -454,7 +459,8 @@ def compute_ensemble_averages(
 
     Returns:
         A dictionary containing the ensemble averages of the potential energy
-        [kcal/mol], volume [Å^3], density [g/mL], and enthalpy [kcal/mol].
+        [kcal/mol], volume [Å^3], density [g/mL], and enthalpy [kcal/mol],
+        as well as their standard deviations.
     """
     tensors, parameter_lookup, attribute_lookup, has_v_sites = _pack_force_field(
         force_field
@@ -480,6 +486,8 @@ def compute_ensemble_averages(
     }
 
     *avg_outputs, columns = _EnsembleAverageOp.apply(kwargs, *tensors)
+    columns = [*columns, *[f"{c}_std" for c in columns]]
+
     return {column: avg for avg, column in zip(avg_outputs, columns)}
 
 

--- a/smee/tests/mm/test_ops.py
+++ b/smee/tests/mm/test_ops.py
@@ -400,6 +400,9 @@ def test_reweight_ensemble_averages(mocker, tmp_path, mock_argon_tensors):
     )
 
     for observable in ensemble_averages:
+        if observable.endswith("_std"):
+            continue
+
         (ensemble_grad,) = torch.autograd.grad(
             ensemble_averages[observable], vdw_parameters, retain_graph=True
         )

--- a/smee/tests/mm/test_ops.py
+++ b/smee/tests/mm/test_ops.py
@@ -304,17 +304,32 @@ def test_compute_ensemble_averages(mocker, tmp_path, mock_argon_tensors):
 
     assert mock_compute_observables.call_count == 1
 
+    assert ensemble_avgs["potential_energy_std"].grad_fn is None
+    assert torch.isclose(
+        ensemble_avgs["potential_energy_std"], torch.std(torch.tensor([1.0, 5.0]))
+    )
+
     ensemble_avgs["potential_energy"].backward(retain_graph=True)
     energy_grad = tensor_ff.potentials_by_type["vdW"].parameters.grad
     tensor_ff.potentials_by_type["vdW"].parameters.grad = None
 
     mock_compute_observables.assert_called_once()
 
+    assert ensemble_avgs["volume_std"].grad_fn is None
+    assert torch.isclose(
+        ensemble_avgs["volume_std"], torch.std(torch.tensor([2.0, 6.0]))
+    )
+
     ensemble_avgs["volume"].backward(retain_graph=True)
     volume_grad = tensor_ff.potentials_by_type["vdW"].parameters.grad
     tensor_ff.potentials_by_type["vdW"].parameters.grad = None
 
     mock_compute_observables.assert_called_once()
+
+    assert ensemble_avgs["density_std"].grad_fn is None
+    assert torch.isclose(
+        ensemble_avgs["density_std"], torch.std(torch.tensor([3.0, 20.0]))
+    )
 
     ensemble_avgs["density"].backward(retain_graph=False)
     density_grad = tensor_ff.potentials_by_type["vdW"].parameters.grad

--- a/smee/tests/test_utils.py
+++ b/smee/tests/test_utils.py
@@ -182,6 +182,18 @@ def test_tensor_like():
     assert torch.allclose(tensor, torch.tensor(expected_data, dtype=expected_type))
 
 
+def test_tensor_like_copy():
+    expected_type = torch.float16
+    expected_data = torch.tensor([[3.0], [2.0], [1.0]], requires_grad=True)
+
+    other = torch.tensor(expected_data, dtype=expected_type, device="cpu")
+    tensor = smee.utils.tensor_like(expected_data, other)
+
+    assert tensor.requires_grad is False
+    assert tensor.dtype == expected_type
+    assert torch.allclose(tensor, torch.tensor(expected_data, dtype=expected_type))
+
+
 def test_arange_like():
     expected_type = torch.int8
     expected_data = [0, 1, 2, 3]

--- a/smee/utils.py
+++ b/smee/utils.py
@@ -90,6 +90,10 @@ def zeros_like(size: _size, other: torch.Tensor) -> torch.Tensor:
 
 def tensor_like(data: typing.Any, other: torch.Tensor) -> torch.Tensor:
     """Create a tensor with the same device and type as another tensor."""
+
+    if isinstance(data, torch.Tensor):
+        return data.clone().detach().to(other.device, other.dtype)
+
     return torch.tensor(data, dtype=other.dtype, device=other.device)
 
 


### PR DESCRIPTION
## Description

This PR adds std errors to the dict returned by the ensemble average op

## Notes

- This PR does not add errors to re-weighting for now. That will be handled in a future PR.

## Status
- [X] Ready to go