### PR TITLE
Fix `pydantic >=2.5` module not found error

### DIFF
--- a/smee/mm/_config.py
+++ b/smee/mm/_config.py
@@ -58,7 +58,7 @@ class _OpenMMQuantityAnnotation:
         cls,
         _core_schema: pydantic_core.core_schema.CoreSchema,
         handler: pydantic.GetJsonSchemaHandler,
-    ) -> pydantic.json_schema.JsonSchemaValue:
+    ) -> "pydantic.json_schema.JsonSchemaValue":
         return handler(pydantic_core.core_schema.str_schema())
 
 


### PR DESCRIPTION
## Description

It looks like this module was possibly made unavailable, even though the file still seems to exist...

## Status
- [X] Ready to go