### PR TITLE
Support custom non-bonded exceptions

### DIFF
--- a/smee/_models.py
+++ b/smee/_models.py
@@ -299,6 +299,18 @@ class TensorPotential:
     attribute_units: tuple[openff.units.Unit, ...] | None = None
     """The units of each attribute in ``attributes``."""
 
+    exceptions: torch.Tensor | None = None
+    """A lookup for custom cross-interaction parameters that should override any mixing
+    rules, with ``shape=n_parameters * (n_parameters - 1) // 2`` and ``dtype=int``.
+
+    It stores the sparse, upper triangular portion of an ``n_parameters x n_parameters``
+    matrix, which serves as lookup from pairs of parameter indices ``(i, j)`` to the
+    index of the parameter in ``parameters``.
+
+    As a note of caution, not all potentials (e.g. common valence potentials) support
+    such exceptions, and these are predominantly useful for non-bonded potentials.
+    """
+
     def to(
         self, device: DeviceType | None = None, precision: Precision | None = None
     ) -> "TensorPotential":
@@ -317,6 +329,7 @@ class TensorPotential:
             ),
             self.attribute_cols,
             self.attribute_units,
+            (None if self.exceptions is None else _cast(self.exceptions, device)),
         )
 
 

--- a/smee/_models.py
+++ b/smee/_models.py
@@ -307,6 +307,9 @@ class TensorPotential:
     should be overridden, and each value the index of the parameter that contains the
     'pre-mixed' parameter to use instead.
 
+    For now, all exceptions are assumed to be symmetric, i.e. if (a, b) is an exception
+    then (b, a) is also an exception, and so only one of the two should be defined.
+
     As a note of caution, not all potentials (e.g. common valence potentials) support
     such exceptions, and these are predominantly useful for non-bonded potentials.
     """

--- a/smee/_models.py
+++ b/smee/_models.py
@@ -299,13 +299,13 @@ class TensorPotential:
     attribute_units: tuple[openff.units.Unit, ...] | None = None
     """The units of each attribute in ``attributes``."""
 
-    exceptions: torch.Tensor | None = None
+    exceptions: dict[tuple[int, int], int] | None = None
     """A lookup for custom cross-interaction parameters that should override any mixing
-    rules, with ``shape=n_parameters * (n_parameters - 1) // 2`` and ``dtype=int``.
+    rules.
 
-    It stores the sparse, upper triangular portion of an ``n_parameters x n_parameters``
-    matrix, which serves as lookup from pairs of parameter indices ``(i, j)`` to the
-    index of the parameter in ``parameters``.
+    Each key should correspond to the indices of the two parameters whose mixing rule
+    should be overridden, and each value the index of the parameter that contains the
+    'pre-mixed' parameter to use instead.
 
     As a note of caution, not all potentials (e.g. common valence potentials) support
     such exceptions, and these are predominantly useful for non-bonded potentials.
@@ -329,7 +329,7 @@ class TensorPotential:
             ),
             self.attribute_cols,
             self.attribute_units,
-            (None if self.exceptions is None else _cast(self.exceptions, device)),
+            self.exceptions,
         )
 
 

--- a/smee/converters/openmm.py
+++ b/smee/converters/openmm.py
@@ -240,20 +240,20 @@ def _convert_lj_potential(
                 force.addParticle(0.0, sigma * _ANGSTROM, epsilon * _KCAL_PER_MOL)
 
             for index, (i, j) in enumerate(parameter_map.exclusions):
+                scale = potential.attributes[parameter_map.exclusion_scale_idxs[index]]
+
                 eps_i, sig_i = parameters[i, :]
                 eps_j, sig_j = parameters[j, :]
 
-                eps = mixing_fn["epsilon"](eps_i, eps_j)
+                eps = mixing_fn["epsilon"](eps_i, eps_j) * scale
                 sig = mixing_fn["sigma"](sig_i, sig_j)
-
-                scale = potential.attributes[parameter_map.exclusion_scale_idxs[index]]
 
                 force.addException(
                     i + idx_offset,
                     j + idx_offset,
                     0.0,
                     sig * _ANGSTROM,
-                    eps * _KCAL_PER_MOL * scale,
+                    eps * _KCAL_PER_MOL,
                 )
 
             idx_offset += topology.n_particles

--- a/smee/potentials/__init__.py
+++ b/smee/potentials/__init__.py
@@ -1,6 +1,7 @@
 """Evaluate the potential energy of parameterized topologies."""
 
 from smee.potentials._potentials import (
+    broadcast_exceptions,
     broadcast_idxs,
     broadcast_parameters,
     compute_energy,
@@ -9,6 +10,7 @@ from smee.potentials._potentials import (
 )
 
 __all__ = [
+    "broadcast_exceptions",
     "broadcast_idxs",
     "broadcast_parameters",
     "compute_energy",

--- a/smee/potentials/nonbonded.py
+++ b/smee/potentials/nonbonded.py
@@ -473,8 +473,8 @@ def compute_lj_energy(
             system, potential, pairwise.idxs[:, 0], pairwise.idxs[:, 1]
         )
 
-        epsilon[exception_idxs] = exceptions[epsilon_column]
-        sigma[exception_idxs] = exceptions[sigma_column]
+        epsilon[exception_idxs] = exceptions[:, epsilon_column]
+        sigma[exception_idxs] = exceptions[:, sigma_column]
 
     x = (sigma / pairwise.distances) ** 6
     energies = pair_scales * 4.0 * epsilon * (x * (x - 1.0))
@@ -722,8 +722,8 @@ def compute_dexp_energy(
             system, potential, pairwise.idxs[:, 0], pairwise.idxs[:, 1]
         )
 
-        epsilon[exception_idxs] = exceptions[epsilon_column]
-        r_min[exception_idxs] = exceptions[r_min_column]
+        epsilon[exception_idxs] = exceptions[:, epsilon_column]
+        r_min[exception_idxs] = exceptions[:, r_min_column]
 
     alpha = potential.attributes[potential.attribute_cols.index("alpha")]
     beta = potential.attributes[potential.attribute_cols.index("beta")]
@@ -962,7 +962,7 @@ def compute_coulomb_energy(
         raise ValueError("the distance cutoff does not match the potential.")
 
     if potential.exceptions is not None:
-        raise NotImplementedError("exceptions are not yet supported.")
+        raise NotImplementedError("exceptions are not supported for charges.")
 
     if system.is_periodic:
         return _compute_coulomb_energy_periodic(

--- a/smee/potentials/nonbonded.py
+++ b/smee/potentials/nonbonded.py
@@ -203,7 +203,10 @@ def compute_pairwise(
         return _compute_pairwise_non_periodic(conformer)
 
 
-def prepare_lrc_types(system: smee.TensorSystem, potential: smee.TensorPotential):
+def prepare_lrc_types(
+    system: smee.TensorSystem,
+    potential: smee.TensorPotential,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Finds the unique vdW interactions present in a system, ready to use
     for computing the long range dispersion correction.
 
@@ -214,8 +217,8 @@ def prepare_lrc_types(system: smee.TensorSystem, potential: smee.TensorPotential
     Returns:
         Two tensors containing the i and j indices into ``potential.paramaters`` of
         each unique interaction parameter excluding ``i==j``, the number of ``ii``
-        interactions with ``shape=(n_params,)``, the numbers of ``ij`` interactions
-        with ``shape=(len(idxs_i),)``, and the total number of interactions.
+        interactions with ``shape=(n_params,)``, and the numbers of ``ij`` interactions
+        with ``shape=(len(idxs_i),)``.
     """
     n_by_type = collections.defaultdict(int)
 
@@ -383,13 +386,35 @@ def _compute_lj_lrc(
         system, potential
     )
 
+    eps_col = potential.parameter_cols.index("epsilon")
+    sig_col = potential.parameter_cols.index("sigma")
+
     eps_ii, sig_ii = (
-        potential.parameters[:, potential.parameter_cols.index("epsilon")],
-        potential.parameters[:, potential.parameter_cols.index("sigma")],
+        potential.parameters[:, eps_col],
+        potential.parameters[:, sig_col],
     )
     eps_ij, sig_ij = smee.potentials.nonbonded.lorentz_berthelot(
         eps_ii[idxs_i], eps_ii[idxs_j], sig_ii[idxs_i], sig_ii[idxs_j]
     )
+
+    if potential.exceptions is not None:
+        exceptions = {
+            **potential.exceptions,
+            **{(j, i): idx for (i, j), idx in potential.exceptions.items()},
+        }
+
+        eps_ij, sig_ij = eps_ij.clone(), sig_ij.clone()  # prevent in-place modification
+
+        for i, (idx_i, idx_j) in enumerate(zip(idxs_i, idxs_j, strict=True)):
+            idx_i, idx_j = int(idx_i), int(idx_j)
+
+            if (idx_i, idx_j) not in exceptions:
+                continue
+
+            param_idx = exceptions[(idx_i, idx_j)]
+
+            eps_ij[i] = potential.parameters[param_idx, eps_col]
+            sig_ij[i] = potential.parameters[param_idx, sig_col]
 
     integral = sig_ij**12 / (9 * rc**9) - sig_ij**6 / (3 * rc**3)
 
@@ -458,14 +483,14 @@ def compute_lj_energy(
     )
     pair_scales = pair_scales[pairs_1d]
 
-    epsilon_column = potential.parameter_cols.index("epsilon")
-    sigma_column = potential.parameter_cols.index("sigma")
+    eps_column = potential.parameter_cols.index("epsilon")
+    sig_column = potential.parameter_cols.index("sigma")
 
-    epsilon, sigma = lorentz_berthelot(
-        parameters[pairwise.idxs[:, 0], epsilon_column],
-        parameters[pairwise.idxs[:, 1], epsilon_column],
-        parameters[pairwise.idxs[:, 0], sigma_column],
-        parameters[pairwise.idxs[:, 1], sigma_column],
+    eps, sig = lorentz_berthelot(
+        parameters[pairwise.idxs[:, 0], eps_column],
+        parameters[pairwise.idxs[:, 1], eps_column],
+        parameters[pairwise.idxs[:, 0], sig_column],
+        parameters[pairwise.idxs[:, 1], sig_column],
     )
 
     if potential.exceptions is not None:
@@ -473,11 +498,13 @@ def compute_lj_energy(
             system, potential, pairwise.idxs[:, 0], pairwise.idxs[:, 1]
         )
 
-        epsilon[exception_idxs] = exceptions[:, epsilon_column]
-        sigma[exception_idxs] = exceptions[:, sigma_column]
+        eps, sig = eps.clone(), sig.clone()  # prevent in-place modification
 
-    x = (sigma / pairwise.distances) ** 6
-    energies = pair_scales * 4.0 * epsilon * (x * (x - 1.0))
+        eps[exception_idxs] = exceptions[:, eps_column]
+        sig[exception_idxs] = exceptions[:, sig_column]
+
+    x = (sig / pairwise.distances) ** 6
+    energies = pair_scales * 4.0 * eps * (x * (x - 1.0))
 
     if not system.is_periodic:
         return energies.sum(-1)
@@ -619,13 +646,36 @@ def _compute_dexp_lrc(
     alpha = potential.attributes[potential.attribute_cols.index("alpha")]
     beta = potential.attributes[potential.attribute_cols.index("beta")]
 
+    eps_col = potential.parameter_cols.index("epsilon")
+    r_min_col = potential.parameter_cols.index("r_min")
+
     eps_ii, r_min_ii = (
-        potential.parameters[:, potential.parameter_cols.index("epsilon")],
-        potential.parameters[:, potential.parameter_cols.index("r_min")],
+        potential.parameters[:, eps_col],
+        potential.parameters[:, r_min_col],
     )
     eps_ij, r_min_ij = smee.potentials.nonbonded.lorentz_berthelot(
         eps_ii[idxs_i], eps_ii[idxs_j], r_min_ii[idxs_i], r_min_ii[idxs_j]
     )
+
+    if potential.exceptions is not None:
+        exceptions = {
+            **potential.exceptions,
+            **{(j, i): idx for (i, j), idx in potential.exceptions.items()},
+        }
+
+        # prevent in-place modification
+        eps_ij, r_min_ij = eps_ij.clone(), r_min_ij.clone()
+
+        for i, (idx_i, idx_j) in enumerate(zip(idxs_i, idxs_j, strict=True)):
+            idx_i, idx_j = int(idx_i), int(idx_j)
+
+            if (idx_i, idx_j) not in exceptions:
+                continue
+
+            param_idx = exceptions[(idx_i, idx_j)]
+
+            eps_ij[i] = potential.parameters[param_idx, eps_col]
+            r_min_ij[i] = potential.parameters[param_idx, r_min_col]
 
     a_rep = beta * torch.exp(alpha) / (alpha - beta)
     b_rep = alpha / r_min_ij
@@ -707,12 +757,12 @@ def compute_dexp_energy(
     )
     pair_scales = pair_scales[pairs_1d]
 
-    epsilon_column = potential.parameter_cols.index("epsilon")
+    eps_column = potential.parameter_cols.index("epsilon")
     r_min_column = potential.parameter_cols.index("r_min")
 
-    epsilon, r_min = smee.potentials.nonbonded.lorentz_berthelot(
-        parameters[pairwise.idxs[:, 0], epsilon_column],
-        parameters[pairwise.idxs[:, 1], epsilon_column],
+    eps, r_min = smee.potentials.nonbonded.lorentz_berthelot(
+        parameters[pairwise.idxs[:, 0], eps_column],
+        parameters[pairwise.idxs[:, 1], eps_column],
         parameters[pairwise.idxs[:, 0], r_min_column],
         parameters[pairwise.idxs[:, 1], r_min_column],
     )
@@ -722,7 +772,9 @@ def compute_dexp_energy(
             system, potential, pairwise.idxs[:, 0], pairwise.idxs[:, 1]
         )
 
-        epsilon[exception_idxs] = exceptions[:, epsilon_column]
+        eps, r_min = eps.clone(), r_min.clone()  # prevent in-place modification
+
+        eps[exception_idxs] = exceptions[:, eps_column]
         r_min[exception_idxs] = exceptions[:, r_min_column]
 
     alpha = potential.attributes[potential.attribute_cols.index("alpha")]
@@ -733,7 +785,7 @@ def compute_dexp_energy(
     energies_repulsion = beta / (alpha - beta) * torch.exp(alpha * (1.0 - x))
     energies_attraction = alpha / (alpha - beta) * torch.exp(beta * (1.0 - x))
 
-    energies = pair_scales * epsilon * (energies_repulsion - energies_attraction)
+    energies = pair_scales * eps * (energies_repulsion - energies_attraction)
 
     if not system.is_periodic:
         return energies.sum(-1)

--- a/smee/tests/convertors/test_openmm.py
+++ b/smee/tests/convertors/test_openmm.py
@@ -11,7 +11,7 @@ import smee.mm
 import smee.potentials
 import smee.tests.utils
 from smee.converters.openmm import (
-    _convert_lj_potential_with_exceptions,
+    convert_to_openmm_force,
     convert_to_openmm_system,
     convert_to_openmm_topology,
     create_openmm_system,
@@ -206,7 +206,7 @@ def test_convert_lj_potential_with_exceptions(with_exception):
 
     vdw_potential.exceptions = {} if not with_exception else vdw_potential.exceptions
 
-    forces = _convert_lj_potential_with_exceptions(vdw_potential, system)
+    forces = convert_to_openmm_force(vdw_potential, system)
 
     assert len(forces) == 2
 

--- a/smee/tests/convertors/test_openmm.py
+++ b/smee/tests/convertors/test_openmm.py
@@ -224,9 +224,6 @@ def test_convert_lj_potential_with_exceptions(with_exception):
     for force in forces:
         omm_system.addForce(force)
 
-    with open("test.xml", "w") as f:
-        f.write(openmm.XmlSerializer.serialize(omm_system))
-
     context = openmm.Context(
         omm_system,
         openmm.VerletIntegrator(1.0),

--- a/smee/tests/convertors/test_openmm.py
+++ b/smee/tests/convertors/test_openmm.py
@@ -4,10 +4,14 @@ import openff.toolkit
 import openff.units
 import openmm
 import pytest
+import torch
 
 import smee
 import smee.mm
+import smee.potentials
+import smee.tests.utils
 from smee.converters.openmm import (
+    _convert_lj_potential_with_exceptions,
     convert_to_openmm_system,
     convert_to_openmm_topology,
     create_openmm_system,
@@ -193,6 +197,50 @@ def test_convert_to_openmm_system_periodic():
 
     _compare_smee_and_interchange(
         tensor_ff, tensor_system, interchange_top, coords, box_vectors
+    )
+
+
+@pytest.mark.parametrize("with_exception", [True, False])
+def test_convert_lj_potential_with_exceptions(with_exception):
+    system, vdw_potential, _ = smee.tests.utils.system_with_exceptions()
+
+    vdw_potential.exceptions = {} if not with_exception else vdw_potential.exceptions
+
+    forces = _convert_lj_potential_with_exceptions(vdw_potential, system)
+
+    assert len(forces) == 2
+
+    assert isinstance(forces[0], openmm.CustomNonbondedForce)
+    assert isinstance(forces[1], openmm.CustomBondForce)
+
+    coords = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]
+    )
+    expected_energy = smee.compute_energy_potential(system, vdw_potential, coords)
+
+    omm_system = openmm.System()
+    for _ in range(system.n_atoms):
+        omm_system.addParticle(1.0)
+    for force in forces:
+        omm_system.addForce(force)
+
+    with open("test.xml", "w") as f:
+        f.write(openmm.XmlSerializer.serialize(omm_system))
+
+    context = openmm.Context(
+        omm_system,
+        openmm.VerletIntegrator(1.0),
+        openmm.Platform.getPlatformByName("Reference"),
+    )
+    context.setPositions(coords.numpy() * openmm.unit.angstrom)
+
+    energy = (
+        context.getState(getEnergy=True)
+        .getPotentialEnergy()
+        .value_in_unit(openmm.unit.kilocalorie_per_mole)
+    )
+    assert torch.isclose(
+        torch.tensor(energy, dtype=expected_energy.dtype), expected_energy
     )
 
 

--- a/smee/tests/potentials/test_nonbonded.py
+++ b/smee/tests/potentials/test_nonbonded.py
@@ -1,12 +1,18 @@
+import math
+
 import numpy
+import openff.toolkit
+import openff.units
 import openmm.unit
 import pytest
 import torch
 
+import smee
 import smee.converters
 import smee.converters.openmm
 import smee.mm
 import smee.tests.utils
+import smee.utils
 from smee.potentials.nonbonded import (
     _COULOMB_PRE_FACTOR,
     DEXP_POTENTIAL,
@@ -51,6 +57,10 @@ def _compute_openmm_energy(
     omm_energy = omm_energy.value_in_unit(openmm.unit.kilocalories_per_mole)
 
     return torch.tensor(omm_energy, dtype=torch.float64)
+
+
+def _parameter_key_to_idx(potential: smee.TensorPotential, key: str):
+    return next(iter(i for i, k in enumerate(potential.parameter_keys) if k.id == key))
 
 
 def _convert_lj_to_dexp(potential: smee.TensorPotential):
@@ -275,6 +285,138 @@ def test_compute_xxx_energy_non_periodic(energy_fn, convert_fn):
     expected_energy = _compute_openmm_energy(tensor_sys, coords, None, vdw_potential)
 
     assert torch.isclose(energy, expected_energy, atol=1.0e-5)
+
+
+def _expected_energy_lj_exceptions(
+    eps_ah, sig_ah, eps_hh, sig_hh, eps_oa, sig_oa, eps_oh, sig_oh
+):
+    sqrt_2 = math.sqrt(2)
+
+    expected_energy = 4.0 * (
+        eps_oh * (sig_oh**12 - sig_oh**6)
+        + eps_oh * (sig_oh**12 - sig_oh**6)
+        #
+        + eps_ah * (sig_ah**12 - sig_ah**6)
+        + eps_ah * (sig_ah**12 - sig_ah**6)
+        #
+        + eps_hh * ((sig_hh / sqrt_2) ** 12 - (sig_hh / sqrt_2) ** 6)
+        #
+        + eps_oa * ((sig_oa / sqrt_2) ** 12 - (sig_oa / sqrt_2) ** 6)
+    )
+    return expected_energy
+
+
+def _expected_energy_dexp_exceptions(
+    eps_ah, sig_ah, eps_hh, sig_hh, eps_oa, sig_oa, eps_oh, sig_oh
+):
+    alpha = 16.5
+    beta = 5.0
+
+    def _dexp(eps, sig, dist):
+        r_min = 2 ** (1 / 6) * sig
+
+        x = dist / r_min
+
+        rep = beta / (alpha - beta) * math.exp(alpha * (1.0 - x))
+        atr = alpha / (alpha - beta) * math.exp(beta * (1.0 - x))
+
+        return eps * (rep - atr)
+
+    sqrt_2 = math.sqrt(2)
+
+    expected_energy = (
+        _dexp(eps_oh, sig_oh, 1.0)
+        + _dexp(eps_oh, sig_oh, 1.0)
+        #
+        + _dexp(eps_ah, sig_ah, 1.0)
+        + _dexp(eps_ah, sig_ah, 1.0)
+        #
+        + _dexp(eps_hh, sig_hh, sqrt_2)
+        #
+        + _dexp(eps_oa, sig_oa, sqrt_2)
+    )
+    return expected_energy
+
+
+@pytest.mark.parametrize(
+    "energy_fn,convert_fn,expected_fn",
+    [
+        (compute_lj_energy, lambda p: p, _expected_energy_lj_exceptions),
+        (compute_dexp_energy, _convert_lj_to_dexp, _expected_energy_dexp_exceptions),
+    ],
+)
+def test_compute_energy_exceptions_non_periodic(energy_fn, convert_fn, expected_fn):
+    ff = openff.toolkit.ForceField()
+
+    kcal = openff.units.unit.kilocalorie / openff.units.unit.mole
+    ang = openff.units.unit.angstrom
+
+    eps_h, sig_h = 0.123, 1.234
+    eps_o, sig_o = 0.234, 2.345
+    eps_a, sig_a = 0.345, 3.456
+
+    eps_hh, sig_hh = 0.3, 1.4
+    eps_ah, sig_ah = 0.4, 2.5
+
+    eps_oh, sig_oh = math.sqrt(eps_o * eps_h), 0.5 * (sig_o + sig_h)
+    eps_oa, sig_oa = math.sqrt(eps_a * eps_o), 0.5 * (sig_a + sig_o)
+
+    vdw_handler = ff.get_parameter_handler("vdW")
+    vdw_handler.add_parameter(
+        {"smirks": "[O:1]", "epsilon": eps_o * kcal, "sigma": sig_o * ang}
+    )
+    vdw_handler.add_parameter(
+        {"smirks": "[H:1]", "epsilon": eps_h * kcal, "sigma": sig_h * ang}
+    )
+    vdw_handler.add_parameter(
+        {"smirks": "[Ar:1]", "epsilon": eps_a * kcal, "sigma": sig_a * ang}
+    )
+
+    system, tensor_ff = smee.tests.utils.system_from_smiles(["O", "[Ar]"], [1, 1], ff)
+    system.is_periodic = False
+
+    vdw_potential = tensor_ff.potentials_by_type["vdW"]
+    vdw_potential.attributes[vdw_potential.attribute_cols.index("scale_12")] = 1.0
+    vdw_potential.attributes[vdw_potential.attribute_cols.index("scale_13")] = 1.0
+
+    parameter_idx_h = _parameter_key_to_idx(vdw_potential, "[H:1]")
+    parameter_idx_a = _parameter_key_to_idx(vdw_potential, "[Ar:1]")
+
+    assert vdw_potential.parameter_cols[0] == "epsilon"
+
+    vdw_potential.parameters = torch.vstack(
+        [vdw_potential.parameters, torch.tensor([[eps_ah, sig_ah], [eps_hh, sig_hh]])]
+    )
+    vdw_potential.parameter_keys = [*vdw_potential.parameter_keys, "ar-h", "h-h"]
+
+    vdw_potential.exceptions = {
+        (parameter_idx_a, parameter_idx_h): 3,
+        (parameter_idx_h, parameter_idx_h): 4,
+    }
+
+    vdw_potential = convert_fn(vdw_potential)
+
+    for top in system.topologies:
+        assignment_matrix = smee.utils.zeros_like(
+            (top.n_particles, len(vdw_potential.parameters)),
+            top.parameters["vdW"].assignment_matrix,
+        )
+        assignment_matrix[:, :3] = top.parameters["vdW"].assignment_matrix.to_dense()
+
+        top.parameters["vdW"].assignment_matrix = assignment_matrix.to_sparse()
+
+    # O --- H
+    # |     |
+    # H --- Ar
+    coords = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]
+    )
+    expected_energy = expected_fn(
+        eps_ah, sig_ah, eps_hh, sig_hh, eps_oa, sig_oa, eps_oh, sig_oh
+    )
+    energy = energy_fn(system, vdw_potential, coords, None)
+
+    assert torch.isclose(energy, torch.tensor(expected_energy, dtype=energy.dtype))
 
 
 def test_coulomb_pre_factor():

--- a/smee/tests/potentials/test_potentials.py
+++ b/smee/tests/potentials/test_potentials.py
@@ -114,14 +114,10 @@ def test_broadcast_exceptions():
     )
     vdw_potential.parameter_keys = [*vdw_potential.parameter_keys, "o-cl", "o-na"]
 
-    exceptions_full = torch.full((6, 6), -1)
-    exceptions_full[parameter_idx_o, parameter_idx_cl] = 4
-    exceptions_full[parameter_idx_cl, parameter_idx_o] = 4
-    exceptions_full[parameter_idx_o, parameter_idx_na] = 5
-    exceptions_full[parameter_idx_na, parameter_idx_o] = 5
-
-    exceptions_idxs = torch.nonzero(torch.triu(exceptions_full), as_tuple=True)
-    vdw_potential.exceptions = exceptions_full[exceptions_idxs]
+    vdw_potential.exceptions = {
+        (parameter_idx_o, parameter_idx_cl): 4,
+        (parameter_idx_o, parameter_idx_na): 5,
+    }
 
     idxs_a = torch.tensor([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 3, 3, 4, 4, 5])
     idxs_b = torch.tensor([3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6, 4, 5, 6, 5, 6, 6])

--- a/smee/tests/test_models.py
+++ b/smee/tests/test_models.py
@@ -64,7 +64,7 @@ class TestTensorTopology:
         topology.residue_idxs = [0]
         assert topology.n_residues == 1
 
-    def test_n_chains(self) -> int:
+    def test_n_chains(self):
         topology = smee.tests.utils.topology_from_smiles("[Ar]")
         topology.residue_ids = [0]
         topology.residue_idxs = ["UNK"]

--- a/smee/tests/utils.py
+++ b/smee/tests/utils.py
@@ -36,7 +36,9 @@ def topology_from_smiles(smiles: str) -> smee.TensorTopology:
 
 
 def system_from_smiles(
-    smiles: list[str], n_copies: list[int]
+    smiles: list[str],
+    n_copies: list[int],
+    force_field: openff.toolkit.ForceField | None = None,
 ) -> tuple[smee.TensorSystem, smee.TensorForceField]:
     """Creates a system from a list of SMILES strings.
 
@@ -47,7 +49,11 @@ def system_from_smiles(
     Returns:
         The system and force field.
     """
-    force_field = openff.toolkit.ForceField("openff-2.0.0.offxml")
+    force_field = (
+        force_field
+        if force_field is not None
+        else openff.toolkit.ForceField("openff-2.0.0.offxml")
+    )
 
     interchanges = [
         openff.interchange.Interchange.from_smirnoff(

--- a/smee/tests/utils.py
+++ b/smee/tests/utils.py
@@ -1,10 +1,37 @@
+import typing
+
 import openff.interchange
 import openff.toolkit
+import openff.units
 import torch
 from rdkit import Chem
 
 import smee
 import smee.converters
+import smee.potentials.nonbonded
+import smee.utils
+
+LJParam = typing.NamedTuple("LJParam", [("eps", float), ("sig", float)])
+
+
+def convert_lj_to_dexp(potential: smee.TensorPotential):
+    potential.fn = smee.potentials.nonbonded.DEXP_POTENTIAL
+
+    parameter_cols = [*potential.parameter_cols]
+    sigma_idx = potential.parameter_cols.index("sigma")
+
+    sigma = potential.parameters[:, sigma_idx]
+    r_min = 2 ** (1 / 6) * sigma
+
+    potential.parameters[:, sigma_idx] = r_min
+
+    parameter_cols[sigma_idx] = "r_min"
+    potential.parameter_cols = tuple(parameter_cols)
+
+    potential.attribute_cols = (*potential.attribute_cols, "alpha", "beta")
+    potential.attributes = torch.cat([potential.attributes, torch.tensor([16.5, 5.0])])
+
+    return potential
 
 
 def topology_from_smiles(smiles: str) -> smee.TensorTopology:
@@ -66,3 +93,79 @@ def system_from_smiles(
     tensor_ff, tensor_tops = smee.converters.convert_interchange(interchanges)
 
     return smee.TensorSystem(tensor_tops, n_copies, is_periodic=True), tensor_ff
+
+
+def _parameter_key_to_idx(potential: smee.TensorPotential, key: str):
+    return next(iter(i for i, k in enumerate(potential.parameter_keys) if k.id == key))
+
+
+def system_with_exceptions() -> (
+    tuple[smee.TensorSystem, smee.TensorPotential, dict[str, LJParam]]
+):
+    ff = openff.toolkit.ForceField()
+
+    kcal = openff.units.unit.kilocalorie / openff.units.unit.mole
+    ang = openff.units.unit.angstrom
+
+    eps_h, sig_h = 0.123, 1.234
+    eps_o, sig_o = 0.234, 2.345
+    eps_a, sig_a = 0.345, 3.456
+
+    eps_hh, sig_hh = 0.3, 1.4
+    eps_ah, sig_ah = 0.4, 2.5
+
+    lj_handler = ff.get_parameter_handler("vdW")
+    lj_handler.add_parameter(
+        {"smirks": "[O:1]", "epsilon": eps_o * kcal, "sigma": sig_o * ang}
+    )
+    lj_handler.add_parameter(
+        {"smirks": "[H:1]", "epsilon": eps_h * kcal, "sigma": sig_h * ang}
+    )
+    lj_handler.add_parameter(
+        {"smirks": "[Ar:1]", "epsilon": eps_a * kcal, "sigma": sig_a * ang}
+    )
+
+    system, tensor_ff = smee.tests.utils.system_from_smiles(["O", "[Ar]"], [1, 1], ff)
+    system.is_periodic = False
+
+    lj_potential = tensor_ff.potentials_by_type["vdW"]
+    lj_potential.attributes[lj_potential.attribute_cols.index("scale_12")] = 1.0
+    lj_potential.attributes[lj_potential.attribute_cols.index("scale_13")] = 1.0
+
+    parameter_idx_h = _parameter_key_to_idx(lj_potential, "[H:1]")
+    parameter_idx_a = _parameter_key_to_idx(lj_potential, "[Ar:1]")
+
+    assert lj_potential.parameter_cols[0] == "epsilon"
+
+    lj_potential.parameters = torch.vstack(
+        [lj_potential.parameters, torch.tensor([[eps_ah, sig_ah], [eps_hh, sig_hh]])]
+    )
+    lj_potential.parameter_keys = [*lj_potential.parameter_keys, "ar-h", "h-h"]
+
+    lj_potential.exceptions = {
+        (parameter_idx_a, parameter_idx_h): 3,
+        (parameter_idx_h, parameter_idx_h): 4,
+    }
+
+    for top in system.topologies:
+        assignment_matrix = smee.utils.zeros_like(
+            (top.n_particles, len(lj_potential.parameters)),
+            top.parameters["vdW"].assignment_matrix,
+        )
+        assignment_matrix[:, :3] = top.parameters["vdW"].assignment_matrix.to_dense()
+
+        top.parameters["vdW"].assignment_matrix = assignment_matrix.to_sparse()
+
+    params = {
+        "oo": LJParam(eps_o, sig_o),
+        "hh": LJParam(eps_hh, sig_hh),
+        "aa": LJParam(eps_a, sig_a),
+        "ah": LJParam(eps_ah, sig_ah),
+        "oh": LJParam((eps_o * eps_h) ** 0.5, 0.5 * (sig_o + sig_h)),
+        "oa": LJParam((eps_a * eps_o) ** 0.5, 0.5 * (sig_a + sig_o)),
+    }
+
+    for k, v in [*params.items()]:
+        params[k[::-1]] = v
+
+    return system, lj_potential, params

--- a/smee/utils.py
+++ b/smee/utils.py
@@ -158,7 +158,9 @@ def logsumexp(
         return ln_exp_sum
 
 
-def to_upper_tri_idx(i: torch.Tensor, j: torch.Tensor, n: int) -> torch.Tensor:
+def to_upper_tri_idx(
+    i: torch.Tensor, j: torch.Tensor, n: int, include_diag: bool = False
+) -> torch.Tensor:
     """Converts pairs of 2D indices to 1D indices in an upper triangular matrix that
     excludes the diagonal.
 
@@ -166,13 +168,19 @@ def to_upper_tri_idx(i: torch.Tensor, j: torch.Tensor, n: int) -> torch.Tensor:
         i: A tensor of the indices along the first axis with ``shape=(n_pairs,)``.
         j: A tensor of the indices along the second axis with ``shape=(n_pairs,)``.
         n: The size of the matrix.
+        include_diag: Whether the diagonal is included in the upper triangular matrix.
 
     Returns:
         A tensor of the indices in the upper triangular matrix with
         ``shape=(n_pairs * (n_pairs - 1) // 2,)``.
     """
-    assert (i < j).all(), "i must be less than j"
-    return (i * (2 * n - i - 1)) // 2 + j - i - 1
+
+    if not include_diag:
+        assert (i < j).all(), "i must be less than j"
+        return (i * (2 * n - i - 1)) // 2 + j - i - 1
+
+    assert (i <= j).all(), "i must be less than or equal to j"
+    return (i * (2 * n - i + 1)) // 2 + j - i
 
 
 class _SafeGeometricMean(torch.autograd.Function):


### PR DESCRIPTION
## Description

This PR adds the ability to add custom exceptions (i.e. override mixing rules) to non-bonded potentials.

## Status
- [X] Ready to go