### PR TITLE
Add support for advanced OpenFF handler converters

### DIFF
--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -17,6 +17,8 @@ dependencies:
   - pydantic
   - nnpops
 
+  - networkx
+
   # Optional packages
 
   ### MM simulations

--- a/smee/converters/openff/_openff.py
+++ b/smee/converters/openff/_openff.py
@@ -303,14 +303,14 @@ def convert_handlers(
         >>>
         >>> vdw_potential, applied_vdw_parameters = convert_handlers(interchanges)
     """
+    importlib.import_module("smee.converters.openff.nonbonded")
+    importlib.import_module("smee.converters.openff.valence")
+
     handler_types = {handler.type for handler in handlers}
     assert len(handler_types) == 1, "multiple handler types found"
     handler_type = next(iter(handler_types))
 
     assert len(handlers) == len(topologies), "mismatched number of topologies"
-
-    importlib.import_module("smee.converters.openff.nonbonded")
-    importlib.import_module("smee.converters.openff.valence")
 
     if handler_type not in _CONVERTERS:
         raise NotImplementedError(f"{handler_type} handlers is not yet supported.")
@@ -456,6 +456,9 @@ def convert_interchange(
         >>>
         >>> tensor_ff, tensor_topologies = convert_interchange(interchanges)
     """
+    importlib.import_module("smee.converters.openff.nonbonded")
+    importlib.import_module("smee.converters.openff.valence")
+
     interchanges = (
         [interchange]
         if isinstance(interchange, openff.interchange.Interchange)

--- a/smee/tests/convertors/openff/test_openff.py
+++ b/smee/tests/convertors/openff/test_openff.py
@@ -12,6 +12,7 @@ from smee.converters.openff._openff import (
     _CONVERTERS,
     _convert_topology,
     _Converter,
+    _resolve_conversion_order,
     convert_handlers,
     convert_interchange,
     smirnoff_parameter_converter,
@@ -98,6 +99,20 @@ def test_convert_topology(formaldehyde, mocker):
     assert topology.parameters == parameters
     assert topology.v_sites == v_sites
     assert topology.constraints == constraints
+
+
+def test_resolve_conversion_order(mocker):
+    mocker.patch.dict(
+        _CONVERTERS,
+        {
+            "a": _Converter(mocker.MagicMock(), {}, ["c"]),
+            "b": _Converter(mocker.MagicMock(), {}, []),
+            "c": _Converter(mocker.MagicMock(), {}, ["b"]),
+        },
+    )
+
+    order = _resolve_conversion_order(["a", "b", "c"])
+    assert order == ["b", "c", "a"]
 
 
 def test_convert_interchange():

--- a/smee/tests/utils.py
+++ b/smee/tests/utils.py
@@ -14,6 +14,17 @@ import smee.utils
 LJParam = typing.NamedTuple("LJParam", [("eps", float), ("sig", float)])
 
 
+def mock_convert_fn_with_deps(
+    handlers: list[openff.interchange.smirnoff.SMIRNOFFvdWCollection],
+    topologies: list[openff.toolkit.Topology],
+    v_site_maps: list[smee.VSiteMap | None],
+    dependencies: dict[
+        str, tuple[smee.TensorPotential, list[smee.NonbondedParameterMap]]
+    ],
+) -> tuple[smee.TensorPotential, list[smee.NonbondedParameterMap]]:
+    raise NotImplementedError()
+
+
 def convert_lj_to_dexp(potential: smee.TensorPotential):
     potential.fn = smee.EnergyFn.VDW_DEXP
 


### PR DESCRIPTION
## Description

@aehogan this is roughly what I was thinking of. Basically it means you can take the already converted electrostatics potential that contains all charges (including due to v-sites, library charges, AM1BCC etc), and then create a new potential that includes both these plus the info from the multiple handler along the lines of

```python
@smee.converters.smirnoff_parameter_converter(
    "Multipole",
    {
        "polarity": _ANGSTROM**3,
        "cutoff": _ANGSTROM
    },
    depends_on=["Electrostatics"]
)
def convert_multipole(
    handlers: list[
        "smirnoff_plugins.collections.nonbonded.SMIRNOFFMultipoleCollection"
    ],
    topologies: list[openff.toolkit.Topology],
    v_site_maps: list[smee.VSiteMap | None],
    dependencies: dict[str, tuple[smee.TensorPotential, list[smee.NonbondedParameterMap]]]
) -> tuple[smee.TensorPotential, list[smee.NonbondedParameterMap]]:
    import smee.potentials.nonbonded

    (
        potential,
        parameter_maps,
    ) = smee.converters.openff.nonbonded.convert_nonbonded_handlers(
        handlers,
        "Multipole",
        topologies,
        v_site_maps,
        ("polarity"),
        ("cutoff"),
    )
    potential.type = smee.PotentialType.POLARIZATION
    potential.fn = smee.EnergyFn.POLARIZATION

    electrostatics_potential, electrostatics_potential_maps = dependencies["Electrostatics"]
    # TODO: merge the two handlers

    # just returning the new potential will lead to the original electrostatics potential being removed,
    # so this new potential should handle all electrostatics interactions.
    return potential, parameter_maps
```

## Status
- [x] Ready to go