### PR TITLE
Drop insider doc dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         make lint
         make test
         make test-examples
-        make docs-build
+        make docs
 
         # TODO: Remove this line once pydantic 1.0 support is dropped
         mamba install --name smee --yes "pydantic <2"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,8 +33,6 @@ jobs:
         fi
 
     - name: Build and Deploy Documentation
-      env:
-        INSIDER_DOCS_TOKEN: ${{ secrets.INSIDER_DOCS_TOKEN }}
       run: |
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
@@ -45,8 +43,4 @@ jobs:
         git pull origin gh-pages --allow-unrelated-histories
 
         make env
-
-        sed -i 's/# extensions/extensions/' mkdocs.yml
-        make docs-insiders INSIDER_DOCS_TOKEN="${INSIDER_DOCS_TOKEN}"
-
         make docs-deploy VERSION="$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CONDA_ENV_RUN := conda run --no-capture-output --name $(PACKAGE_NAME)
 EXAMPLES_SKIP := examples/md-simulations.ipynb
 EXAMPLES := $(filter-out $(EXAMPLES_SKIP), $(wildcard examples/*.ipynb))
 
-.PHONY: env lint format test test-examples docs-build docs-deploy docs-insiders
+.PHONY: env lint format test test-examples docs docs-deploy
 
 env:
 	mamba create     --name $(PACKAGE_NAME)
@@ -28,7 +28,7 @@ test:
 test-examples:
 	$(CONDA_ENV_RUN) jupyter nbconvert --to notebook --execute $(EXAMPLES)
 
-docs-build:
+docs:
 	$(CONDA_ENV_RUN) mkdocs build
 
 docs-deploy:
@@ -36,7 +36,3 @@ ifndef VERSION
 	$(error VERSION is not set)
 endif
 	$(CONDA_ENV_RUN) mike deploy --push --update-aliases $(VERSION)
-
-docs-insiders:
-	$(CONDA_ENV_RUN) pip install git+https://$(INSIDER_DOCS_TOKEN)@github.com/SimonBoothroyd/mkdocstrings-python.git \
-                    			 git+https://$(INSIDER_DOCS_TOKEN)@github.com/SimonBoothroyd/griffe-pydantic.git

--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -55,12 +55,13 @@ dependencies:
   - codecov
 
   # Docs
-  - mkdocs <1.6
+  - mkdocs
   - mkdocs-material
   - mkdocs-gen-files
   - mkdocs-literate-nav
   - mkdocs-jupyter
   - mkdocstrings
-  - mkdocstrings-python
+  - mkdocstrings-python >=1.10.8
+  - griffe-pydantic
   - black
   - mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ plugins:
         import:
          - http://docs.openmm.org/latest/api-python/objects.inv
         options:
-          # extensions: [ griffe_pydantic ]
+          extensions: [ griffe_pydantic ]
           docstring_options:
             ignore_init_summary: true
             returns_multiple_items: false


### PR DESCRIPTION
## Description

`griffe-pydantic` and other nice QoL features are now in the public releases of `mkdocstrings`

## Status
- [X] Ready to go