### PR TITLE
Don't include constrained bonds / angles from OpenFF

### DIFF
--- a/smee/tests/convertors/openff/test_valence.py
+++ b/smee/tests/convertors/openff/test_valence.py
@@ -1,3 +1,7 @@
+import openff.interchange
+import openff.toolkit
+import pytest
+
 from smee.converters.openff.valence import (
     convert_angles,
     convert_bonds,
@@ -9,7 +13,7 @@ from smee.converters.openff.valence import (
 def test_convert_bonds(ethanol, ethanol_interchange):
     bond_collection = ethanol_interchange.collections["Bonds"]
 
-    potential, parameter_maps = convert_bonds([bond_collection])
+    potential, parameter_maps = convert_bonds([bond_collection], [set()])
 
     assert potential.type == "Bonds"
     assert potential.fn == "k/2*(r-length)**2"
@@ -56,13 +60,124 @@ def test_convert_bonds(ethanol, ethanol_interchange):
     assert actual_parameters == expected_parameters
 
 
-def test_convert_angles(ethanol, ethanol_interchange):
+def test_convert_bonds_with_constraints(ethanol):
+    interchange = openff.interchange.Interchange.from_smirnoff(
+        openff.toolkit.ForceField("openff-1.3.0.offxml"), ethanol.to_topology()
+    )
+
+    bond_collection = interchange.collections["Bonds"]
+
+    constraints = {
+        (bond.atom1_index, bond.atom2_index)
+        for bond in ethanol.bonds
+        if bond.atom1.atomic_number == 1 or bond.atom2.atomic_number == 1
+    }
+
+    potential, [parameter_map] = convert_bonds([bond_collection], [constraints])
+    parameter_keys = [key.id for key in potential.parameter_keys]
+
+    assert len(parameter_map.assignment_matrix) == len(parameter_map.particle_idxs)
+    assignment_matrix = parameter_map.assignment_matrix.to_dense()
+
+    actual_parameters = {
+        tuple(particle_idxs.tolist()): parameter_keys[parameter_idxs.nonzero()]
+        for parameter_idxs, particle_idxs in zip(
+            assignment_matrix, parameter_map.particle_idxs, strict=True
+        )
+    }
+    expected_parameters = {(0, 2): "[#6:1]-[#8:2]", (1, 2): "[#6X4:1]-[#6X4:2]"}
+
+    assert actual_parameters == expected_parameters
+
+
+@pytest.mark.parametrize("with_constraints", [True, False])
+def test_convert_angles_etoh(ethanol, ethanol_interchange, with_constraints):
     angle_collection = ethanol_interchange.collections["Angles"]
 
-    potential, parameter_maps = convert_angles([angle_collection])
+    h_bond_idxs = {
+        (bond.atom1_index, bond.atom2_index)
+        for bond in ethanol.bonds
+        if bond.atom1.atomic_number == 1 or bond.atom2.atomic_number == 1
+    }
+    constraints = set() if not with_constraints else h_bond_idxs
+
+    potential, parameter_maps = convert_angles([angle_collection], [constraints])
 
     assert potential.type == "Angles"
     assert potential.fn == "k/2*(theta-angle)**2"
+
+    assert potential.attributes is None
+    assert potential.attribute_cols is None
+
+    assert potential.parameter_cols == ("k", "angle")
+
+    parameter_keys = [key.id for key in potential.parameter_keys]
+    expected_parameter_keys = [
+        "[#1:1]-[#6X4:2]-[#1:3]",
+        "[*:1]-[#8:2]-[*:3]",
+        "[*:1]~[#6X4:2]-[*:3]",
+    ]
+    assert sorted(parameter_keys) == sorted(expected_parameter_keys)
+
+    assert potential.parameters.shape == (3, 2)
+
+    assert len(parameter_maps) == 1
+    parameter_map = parameter_maps[0]
+
+    assert len(parameter_map.assignment_matrix) == len(parameter_map.particle_idxs)
+    assignment_matrix = parameter_map.assignment_matrix.to_dense()
+
+    actual_parameters = {
+        tuple(particle_idxs.tolist()): parameter_keys[parameter_idxs.nonzero()]
+        for parameter_idxs, particle_idxs in zip(
+            assignment_matrix, parameter_map.particle_idxs, strict=True
+        )
+    }
+    expected_parameters = {
+        (0, 2, 1): "[*:1]~[#6X4:2]-[*:3]",
+        (0, 2, 7): "[*:1]~[#6X4:2]-[*:3]",
+        (0, 2, 8): "[*:1]~[#6X4:2]-[*:3]",
+        (1, 2, 7): "[*:1]~[#6X4:2]-[*:3]",
+        (1, 2, 8): "[*:1]~[#6X4:2]-[*:3]",
+        (2, 0, 3): "[*:1]-[#8:2]-[*:3]",
+        (2, 1, 4): "[*:1]~[#6X4:2]-[*:3]",
+        (2, 1, 5): "[*:1]~[#6X4:2]-[*:3]",
+        (2, 1, 6): "[*:1]~[#6X4:2]-[*:3]",
+        (4, 1, 5): "[#1:1]-[#6X4:2]-[#1:3]",
+        (4, 1, 6): "[#1:1]-[#6X4:2]-[#1:3]",
+        (5, 1, 6): "[#1:1]-[#6X4:2]-[#1:3]",
+        (7, 2, 8): "[#1:1]-[#6X4:2]-[#1:3]",
+    }
+
+    assert actual_parameters == expected_parameters
+
+
+@pytest.mark.parametrize("with_constraints", [True, False])
+def test_convert_angle_water(with_constraints):
+    interchange = openff.interchange.Interchange.from_smirnoff(
+        openff.toolkit.ForceField("openff-1.3.0.offxml"),
+        openff.toolkit.Molecule.from_mapped_smiles("[O:1]([H:2])[H:3]").to_topology(),
+    )
+
+    angle_collection = interchange.collections["Angles"]
+
+    constraints = set() if not with_constraints else {(0, 1), (0, 2), (1, 2)}
+
+    potential, [parameter_map] = convert_angles([angle_collection], [constraints])
+    parameter_keys = [key.id for key in potential.parameter_keys]
+
+    assert len(parameter_map.assignment_matrix) == len(parameter_map.particle_idxs)
+    assignment_matrix = parameter_map.assignment_matrix.to_dense()
+
+    actual_parameters = {
+        tuple(particle_idxs.tolist()): parameter_keys[parameter_idxs.nonzero()]
+        for parameter_idxs, particle_idxs in zip(
+            assignment_matrix, parameter_map.particle_idxs, strict=True
+        )
+    }
+    expected_parameters = {} if with_constraints else {(1, 0, 2): "[*:1]-[#8:2]-[*:3]"}
+
+    assert actual_parameters == expected_parameters
 
 
 def test_convert_propers(ethanol, ethanol_interchange):


### PR DESCRIPTION
## Description

Currently all bonds and angles that are assigned parameters are converted into interactions to compute, even if some bonds / angles are constrained by distance constraints.

This PR aligns more closely with how OpenFF Interchange exports to OpenMM, such that constrained bonds, and angles where all atoms are constrained (e.g. water), no longer contribute to the energy

## Status
- [X] Ready to go