### PR TITLE
Update minimum version of smirnoff-plugins

### DIFF
--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -39,7 +39,7 @@ dependencies:
   - jupyter
   - nbconvert
   - nglview
-  - smirnoff-plugins >=0.0.4
+  - smirnoff-plugins >=2025.09.0
 
   # Dev / Testing
   - ambertools


### PR DESCRIPTION
## Description
This avoids errors due to missing openff-models imports and closes https://github.com/openforcefield/smee/issues/136.

## Status
- [x] Ready to go